### PR TITLE
removed period in filename

### DIFF
--- a/edge-integration-cell/external-postgres/get_external_postgres_access.sh
+++ b/edge-integration-cell/external-postgres/get_external_postgres_access.sh
@@ -52,7 +52,7 @@ root_crt=$(kubectl get secret "$secret_name" -n "$namespace" -o json | jq -r '.d
 if [[ -n "$root_crt" ]]; then
     # Write the content to the output file
     echo "$root_crt" > "$output_file"
-    echo "External DB TLS Root Certificate saved to $output_file."
+    echo "External DB TLS Root Certificate saved to $output_file"
 else
     echo "Error: Failed to fetch root.crt from secret $secret_name in namespace $namespace."
 fi


### PR DESCRIPTION
With the period added after the filename, we get a result like below which is misleading the filename.

```
External DB Password: ****
External DB TLS Root Certificate saved to external_postgres_db_tls_root_cert.crt.
```
