### PR TITLE
Added command for resource deletion

### DIFF
--- a/bicep.makefile
+++ b/bicep.makefile
@@ -90,3 +90,8 @@ resource-group-delete:  ## Delete the Azure resource group
 aro-delete:  ## Delete the ARO cluster
 	$(call required-environment-variables,ARO_RESOURCE_GROUP ARO_CLUSTER_NAME)
 	az aro delete --name ${ARO_CLUSTER_NAME} --resource-group ${ARO_RESOURCE_GROUP} --yes --no-wait
+
+.PHONY: aro-delete-resources
+aro-delete-resources:  ## Delete all resources in the ARO resource group
+	$(call required-environment-variables,ARO_RESOURCE_GROUP)
+	az resource delete --resource-group ${ARO_RESOURCE_GROUP} --ids $$(az resource list --resource-group ${ARO_RESOURCE_GROUP} --query "[].id" -o tsv)

--- a/bicep.makefile
+++ b/bicep.makefile
@@ -81,7 +81,7 @@ oc-login:  ## Login with oc to existing ARO cluster
 		-u "$(shell az aro list-credentials --name ${ARO_CLUSTER_NAME} --resource-group ${ARO_RESOURCE_GROUP} --query 'kubeadminUsername' -o tsv)" \
 		-p "$(shell az aro list-credentials --name ${ARO_CLUSTER_NAME} --resource-group ${ARO_RESOURCE_GROUP} --query 'kubeadminPassword' -o tsv)"
 
-.PHONY: resource-group-delete
+.PHONY: aro-resource-group-delete
 resource-group-delete:  ## Delete the Azure resource group
 	$(call required-environment-variables,ARO_RESOURCE_GROUP)
 	az group delete --name ${ARO_RESOURCE_GROUP} --yes --no-wait

--- a/bicep.makefile
+++ b/bicep.makefile
@@ -82,12 +82,12 @@ oc-login:  ## Login with oc to existing ARO cluster
 		-p "$(shell az aro list-credentials --name ${ARO_CLUSTER_NAME} --resource-group ${ARO_RESOURCE_GROUP} --query 'kubeadminPassword' -o tsv)"
 
 .PHONY: aro-resource-group-delete
-resource-group-delete:  ## Delete the Azure resource group
+aro-resource-group-delete:  ## Delete the Azure resource group
 	$(call required-environment-variables,ARO_RESOURCE_GROUP)
 	az group delete --name ${ARO_RESOURCE_GROUP} --yes --no-wait
 
-.PHONY: aro-delete
-aro-delete:  ## Delete the ARO cluster
+.PHONY: aro-delete-cluster
+aro-delete-cluster:  ## Delete the ARO cluster
 	$(call required-environment-variables,ARO_RESOURCE_GROUP ARO_CLUSTER_NAME)
 	az aro delete --name ${ARO_CLUSTER_NAME} --resource-group ${ARO_RESOURCE_GROUP} --yes --no-wait
 


### PR DESCRIPTION
* Added a command for deleting all the resources present in a resource-group. (the resource-group itself does not get deleted).
* Suggesting a fix for the appending `aro` to the `resource-group-delete`. Because all the other commands have `aro` appended to them, therefore we should maintain uniformity.