### PR TITLE
make crunchy-pgbackrest image tag explicit

### DIFF
--- a/edge-integration-cell/external-postgres/postgrescluster-v15.yaml
+++ b/edge-integration-cell/external-postgres/postgrescluster-v15.yaml
@@ -30,6 +30,7 @@ spec:
       options: 'SUPERUSER'
   backups:
     pgbackrest:
+      image: registry.connect.redhat.com/crunchydata/crunchy-pgbackrest:ubi8-15.12-0
       global:
         repo1-retention-full: "1"
         repo1-retention-full-type: count


### PR DESCRIPTION
Fix the issue of  Normal   Pulling                 21m                 kubelet                  Pulling image registry.connect.redhat.com/crunchydata/crunchy-pgbackrest@sha256:826e579759b43ee2f1533f6d8d64f694a756d384db66e54f99aa43a7d015ae0f

  Warning  Failed                  21m                 kubelet                  Failed to pull image registry.connect.redhat.com/crunchydata/crunchy-pgbackrest@sha256:826e579759b43ee2f1533f6d8d64f694a756d384db66e54f99aa43a7d015ae0f: initializing source docker://registry.connect.redhat.com/crunchydata/crunchy-pgbackrest@sha256:826e579759b43ee2f1533f6d8d64f694a756d384db66e54f99aa43a7d015ae0f: reading manifest sha256:826e579759b43ee2f1533f6d8d64f694a756d384db66e54f99aa43a7d015ae0f in registry.connect.redhat.com/crunchydata/crunchy-pgbackrest: name unknown: Image not found

  Warning  Failed                  21m                 kubelet                  Error: ErrImagePull

  Warning  Failed                  21m (x2 over 21m)   kubelet                  Error: ImagePullBackOff