### PR TITLE
[Validation] external cloud connector test

### DIFF
--- a/.tekton/hcp-kubevirt-validation-pipelinerun.yaml
+++ b/.tekton/hcp-kubevirt-validation-pipelinerun.yaml
@@ -61,7 +61,7 @@ spec:
     - name: jiraSecretName
       value: "jira-secret-mj"
     - name: jiraIssueKey
-      value: ""
+      value: "SAPOCP-1951"
     - name: skipTeardown
       value: "false"
     - name: hubKubeconfigSecretName

--- a/.tekton/hcp-kubevirt-validation-pipelinerun.yaml
+++ b/.tekton/hcp-kubevirt-validation-pipelinerun.yaml
@@ -33,7 +33,7 @@ spec:
     - name: hostedClusterNamespace
       value: "clusters"
     - name: releaseImage
-      value: "quay.io/openshift-release-dev/ocp-release:4.20.9-x86_64"
+      value: "quay.io/openshift-release-dev/ocp-release:4.20.16-x86_64"
     - name: nodePoolReplicas
       value: "3"
     - name: nodePoolCpuCores


### PR DESCRIPTION
…ase image

Add PipelineRun to .tekton/ for Pipelines-as-Code auto-triggering on PRs, and downgrade release image to 4.20.9 in the example.