### PR TITLE
fix: set valkey RDB save directory to writable PVC path

### DIFF
--- a/edge-integration-cell/external-valkey/charts/redhat-valkey-persistent/src/templates/deployment.yaml
+++ b/edge-integration-cell/external-valkey/charts/redhat-valkey-persistent/src/templates/deployment.yaml
@@ -38,6 +38,8 @@ spec:
         {{- if .Values.tls.enabled }}
         args:
           - valkey-server
+          - --dir
+          - /var/lib/valkey/data
           - --requirepass
           - $(VALKEY_PASSWORD)
           - --tls-port

--- a/edge-integration-cell/external-valkey/cleanup_valkey.sh
+++ b/edge-integration-cell/external-valkey/cleanup_valkey.sh
@@ -92,6 +92,13 @@ check_prerequisites() {
         exit 1
     fi
 
+    local helm_major
+    helm_major=$(helm version --short 2>/dev/null | grep -oE 'v[0-9]+' | head -1 | tr -d 'v')
+    if [[ -z "$helm_major" || "$helm_major" -lt 3 ]]; then
+        log_error "Helm v3+ is required. Current version: $(helm version --short 2>/dev/null || echo 'unknown')"
+        exit 1
+    fi
+
     if ! oc whoami &> /dev/null; then
         log_error "Not logged into OpenShift cluster"
         exit 1

--- a/edge-integration-cell/external-valkey/deploy_valkey.sh
+++ b/edge-integration-cell/external-valkey/deploy_valkey.sh
@@ -104,6 +104,13 @@ check_prerequisites() {
         exit 1
     fi
 
+    local helm_major
+    helm_major=$(helm version --short 2>/dev/null | grep -oE 'v[0-9]+' | head -1 | tr -d 'v')
+    if [[ -z "$helm_major" || "$helm_major" -lt 3 ]]; then
+        log_error "Helm v3+ is required. Current version: $(helm version --short 2>/dev/null || echo 'unknown')"
+        exit 1
+    fi
+
     if ! oc whoami &> /dev/null; then
         log_error "Not logged into OpenShift cluster"
         exit 1

--- a/edge-integration-cell/external-valkey/deploy_valkey.sh
+++ b/edge-integration-cell/external-valkey/deploy_valkey.sh
@@ -215,8 +215,8 @@ wait_for_valkey() {
     local attempt=0
 
     while [[ $attempt -lt $max_attempts ]]; do
-        if oc get pods -l name=valkey -n "$NAMESPACE" 2>/dev/null | grep -q "Running"; then
-            log_info "Valkey pod is running"
+        if oc get pods -l name=valkey -n "$NAMESPACE" 2>/dev/null | grep -q "1/1.*Running"; then
+            log_info "Valkey pod is ready"
             return 0
         fi
         attempt=$((attempt + 1))


### PR DESCRIPTION
When TLS is enabled, the container args override the default entrypoint without setting --dir, causing Valkey to write RDB snapshots to the read-only /opt/app-root/src. This fails under OpenShift restricted SCC with "Permission denied". Point --dir to /var/lib/valkey/data where the PVC is mounted.