### PR TITLE
add LokiStack logging task to HCP OSSM3 validation pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,5 @@ rosa/terraform/.terraform.lock.hcl
 
 CLAUDE.md
 .claude/
+.tekton/kba*.md
 rosa/terraform/create-approvers-simple.sh

--- a/.tekton-examples/hcp-ossm3-validation-run.yaml
+++ b/.tekton-examples/hcp-ossm3-validation-run.yaml
@@ -42,7 +42,7 @@ spec:
     # hostedClusterName: include hubClusterName to avoid collisions across hubs
     # Pattern: {prefix}-{hubClusterName}-pr{number}
     - name: hostedClusterName
-      value: "hcp-ossm-eli-pr{{ pull_request_number }}"
+      value: "hcp-ossm-eic-pr{{ pull_request_number }}"
     # hostedClusterName: include hubClusterName to avoid collisions across hubs
     # Pattern: {prefix}-{hubClusterName}-pr{number}
     - name: hostedClusterNamespace
@@ -81,7 +81,7 @@ spec:
     - name: postgresHA
       value: "false"
     - name: datastoreType
-      value: "redis"
+      value: "valkey-cluster"
     - name: redisClusterType
       value: "standard"
 

--- a/.tekton/pipelines/hcp-ossm3-validation-pipeline.yaml
+++ b/.tekton/pipelines/hcp-ossm3-validation-pipeline.yaml
@@ -114,6 +114,22 @@ spec:
       description: "Jira issue key to update with deployment results"
       default: ""
 
+    # --- Logging parameters ---
+    - name: lokiSize
+      type: string
+      description: "LokiStack size (1x.extra-small for test/validation, 1x.small for production)"
+      default: "1x.extra-small"
+
+    # --- Tracing parameters ---
+    - name: istioNamespace
+      type: string
+      description: "Namespace where Istio control plane is deployed"
+      default: "istio-system"
+    - name: istioCRName
+      type: string
+      description: "Name of the Istio CR to patch with tracing extension providers"
+      default: "default"
+
     # --- Pipeline control ---
     - name: skipTeardown
       type: string
@@ -364,9 +380,60 @@ spec:
         - name: source
           workspace: source
 
-    # Step 12: Get all credentials and display them
+    # Step 12a: Deploy LokiStack logging on hosted cluster (parallel with DB deployment)
+    - name: deploy-logging
+      runAfter: [generate-sa-based-kubeconfig]
+      taskRef: { name: hcp-deploy-logging }
+      params:
+        - name: hostedClusterName
+          value: $(params.hostedClusterName)
+        - name: hostedClusterNamespace
+          value: $(params.hostedClusterNamespace)
+        - name: hubKubeconfigSecretName
+          value: $(params.hubClusterName)-kubeconfig
+        - name: lokiSize
+          value: $(params.lokiSize)
+      workspaces:
+        - name: source
+          workspace: source
+
+    # Step 12b: Deploy distributed tracing on hosted cluster (parallel with DB deployment)
+    - name: deploy-tracing
+      runAfter: [generate-sa-based-kubeconfig]
+      taskRef: { name: hcp-deploy-tracing }
+      params:
+        - name: hostedClusterName
+          value: $(params.hostedClusterName)
+        - name: hostedClusterNamespace
+          value: $(params.hostedClusterNamespace)
+        - name: hubKubeconfigSecretName
+          value: $(params.hubClusterName)-kubeconfig
+        - name: istioNamespace
+          value: $(params.istioNamespace)
+        - name: istioCRName
+          value: $(params.istioCRName)
+      workspaces:
+        - name: source
+          workspace: source
+
+    # Step 12c: Deploy Perses dashboards on hosted cluster (parallel with DB deployment)
+    - name: deploy-dashboards
+      runAfter: [generate-sa-based-kubeconfig]
+      taskRef: { name: hcp-deploy-dashboards }
+      params:
+        - name: hostedClusterName
+          value: $(params.hostedClusterName)
+        - name: hostedClusterNamespace
+          value: $(params.hostedClusterNamespace)
+        - name: hubKubeconfigSecretName
+          value: $(params.hubClusterName)-kubeconfig
+      workspaces:
+        - name: source
+          workspace: source
+
+    # Step 13: Get all credentials and display them
     - name: get-all-accesses
-      runAfter: [deploy-postgres, deploy-redis, deploy-valkey]
+      runAfter: [deploy-postgres, deploy-redis, deploy-valkey, deploy-logging, deploy-tracing, deploy-dashboards]
       taskRef: { name: hcp-get-all-accesses }
       params:
         - name: hostedClusterName
@@ -454,9 +521,11 @@ spec:
         - name: source
           workspace: source
 
-    # Step 16: Fix EndpointSlice for Hypershift KubeVirt OCP 4.21 bug
-    #          The service-sync controller may fail to create EndpointSlice
-    #          objects for LoadBalancer services, breaking MetalLB routing.
+    # Step 16: Fix EndpointSlice for OCPBUGS-95615 (HyperShift KubeVirt)
+    #          control-plane-operator puts both VMI IPs per endpoint; kube-proxy
+    #          load-balances to the unreachable guest-cluster IP ~50% of the time.
+    #          Must run before each LoadBalancer test round (CPO reconciles it back
+    #          during long approval gates). Round 3 (Route-based) is unaffected.
     - name: fix-endpointslice
       runAfter: [validate-and-create-configmap]
       taskRef: { name: hcp-fix-endpointslice }
@@ -486,11 +555,11 @@ spec:
         - name: source
           workspace: source
 
-    # Step 18: Endpoint Tests (run in parallel after EndpointSlice fix and Route creation)
+    # Step 18: Endpoint Tests (sequential to avoid MetalLB flakiness on bare-metal KubeVirt)
     # NOTE: httpbinipfilter has an IP filter policy. The hub and managed cluster
     # pod CIDRs must be whitelisted in the iFlow's IP filter settings.
     - name: test-httpbinipfilter
-      runAfter: [fix-endpointslice, create-eic-route]
+      runAfter: [test-http-testelster]
       taskRef: { name: endpoint-tests }
       params:
         - name: endpointPath
@@ -522,7 +591,7 @@ spec:
           workspace: source
 
     - name: test-http-testelster
-      runAfter: [fix-endpointslice, create-eic-route]
+      runAfter: [test-http-test1]
       taskRef: { name: endpoint-tests }
       params:
         - name: endpointPath
@@ -538,7 +607,7 @@ spec:
           workspace: source
 
     - name: test-slvredis
-      runAfter: [fix-endpointslice, create-eic-route]
+      runAfter: [test-httpbinipfilter]
       taskRef: { name: endpoint-tests }
       params:
         - name: endpointPath
@@ -571,12 +640,7 @@ spec:
 
     # Step 19: Manual approval before second round of tests
     - name: approval-second-test-round
-      runAfter:
-        - test-httpbinipfilter
-        - test-http-test1
-        - test-http-testelster
-        - test-slvredis
-        - test-ratelimit-slvredis
+      runAfter: [test-ratelimit-slvredis]
       taskRef:
         apiVersion: openshift-pipelines.org/v1alpha1
         kind: ApprovalTask
@@ -602,9 +666,25 @@ spec:
         - name: timeout
           value: '336h'
 
-    # Step 20: Second round of endpoint tests (LoadBalancer)
-    - name: test-httpbinipfilter-round2
+    # Step 20: Re-apply EndpointSlice fix before Round 2 (CPO may have reconciled
+    #          dual IPs back during the approval gate — OCPBUGS-95615)
+    - name: fix-endpointslice-round2
       runAfter: [approval-second-test-round]
+      taskRef: { name: hcp-fix-endpointslice }
+      params:
+        - name: hostedClusterName
+          value: $(params.hostedClusterName)
+        - name: hostedClusterNamespace
+          value: $(params.hostedClusterNamespace)
+        - name: hubKubeconfigSecretName
+          value: $(params.hubClusterName)-kubeconfig
+      workspaces:
+        - name: source
+          workspace: source
+
+    # Second round of endpoint tests (LoadBalancer)
+    - name: test-httpbinipfilter-round2
+      runAfter: [test-http-testelster-round2]
       taskRef: { name: endpoint-tests }
       params:
         - name: endpointPath
@@ -620,7 +700,7 @@ spec:
           workspace: source
 
     - name: test-http-test1-round2
-      runAfter: [approval-second-test-round]
+      runAfter: [fix-endpointslice-round2]
       taskRef: { name: endpoint-tests }
       params:
         - name: endpointPath
@@ -636,7 +716,7 @@ spec:
           workspace: source
 
     - name: test-http-testelster-round2
-      runAfter: [approval-second-test-round]
+      runAfter: [test-http-test1-round2]
       taskRef: { name: endpoint-tests }
       params:
         - name: endpointPath
@@ -652,7 +732,7 @@ spec:
           workspace: source
 
     - name: test-slvredis-round2
-      runAfter: [approval-second-test-round]
+      runAfter: [test-httpbinipfilter-round2]
       taskRef: { name: endpoint-tests }
       params:
         - name: endpointPath
@@ -685,12 +765,7 @@ spec:
 
     # Step 21: Manual approval before Route-based tests (round 3)
     - name: approval-route-test-round
-      runAfter:
-        - test-httpbinipfilter-round2
-        - test-http-test1-round2
-        - test-http-testelster-round2
-        - test-slvredis-round2
-        - test-ratelimit-slvredis-round2
+      runAfter: [test-ratelimit-slvredis-round2]
       taskRef:
         apiVersion: openshift-pipelines.org/v1alpha1
         kind: ApprovalTask
@@ -722,7 +797,7 @@ spec:
 
     # Step 22: Route-based Endpoint Tests (round 3, via OpenShift Route)
     - name: test-httpbinipfilter-route
-      runAfter: [approval-route-test-round]
+      runAfter: [test-http-testelster-route]
       taskRef: { name: endpoint-tests-expected-status }
       params:
         - name: endpointPath
@@ -756,7 +831,7 @@ spec:
           workspace: source
 
     - name: test-http-testelster-route
-      runAfter: [approval-route-test-round]
+      runAfter: [test-http-test1-route]
       taskRef: { name: endpoint-tests }
       params:
         - name: endpointPath
@@ -772,7 +847,7 @@ spec:
           workspace: source
 
     - name: test-slvredis-route
-      runAfter: [approval-route-test-round]
+      runAfter: [test-httpbinipfilter-route]
       taskRef: { name: endpoint-tests }
       params:
         - name: endpointPath
@@ -805,12 +880,7 @@ spec:
 
     # Step 23: Update Jira with test results
     - name: update-jira-test-results
-      runAfter:
-        - test-httpbinipfilter-route
-        - test-http-test1-route
-        - test-http-testelster-route
-        - test-slvredis-route
-        - test-ratelimit-slvredis-route
+      runAfter: [test-ratelimit-slvredis-route]
       when:
         - input: "$(params.jiraIssueKey)"
           operator: notin

--- a/.tekton/tasks/endpoint-tests-expected-status.yaml
+++ b/.tekton/tasks/endpoint-tests-expected-status.yaml
@@ -110,6 +110,11 @@ spec:
             fi
           fi
 
+          echo ""
+          echo "📋 Manual curl command:"
+          echo "curl -k -s -o /dev/null -w '%{http_code}' --connect-timeout 10 --max-time 30 -H 'Authorization: Basic <AUTH_KEY>' ${RESOLVE_OPT} 'https://${HOST}${ENDPOINT_PATH}'"
+          echo ""
+
           POD_NAME="curl-test-$(date +%s)-${RANDOM}"
           echo "🚀 Running curl via remote pod ${POD_NAME}..."
           OC_OUTPUT=$(oc run "${POD_NAME}" -n default --rm -i --restart=Never \
@@ -132,6 +137,20 @@ spec:
             exit 1
           fi
         else
+          RESOLVE_PRINT=""
+          if [[ "$(params.publicDNS)" != "true" ]]; then
+            if [[ "$INGRESS_IP" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              RESOLVE_PRINT="--resolve ${HOST}:443:${INGRESS_IP}"
+            else
+              RESOLVE_PRINT="--connect-to ${HOST}:443:${INGRESS_IP}:443"
+            fi
+          fi
+
+          echo ""
+          echo "📋 Manual curl command:"
+          echo "curl -k -s -o /dev/null -w '%{http_code}' --connect-timeout 10 --max-time 30 -H 'Authorization: Basic <AUTH_KEY>' ${RESOLVE_PRINT} 'https://${HOST}${ENDPOINT_PATH}'"
+          echo ""
+
           ACTUAL_STATUS=$(curl "${CURL_OPTS[@]}" \
             -H "Authorization: Basic ${AUTH_KEY}" \
             --url "https://${HOST}${ENDPOINT_PATH}")

--- a/.tekton/tasks/endpoint-tests.yaml
+++ b/.tekton/tasks/endpoint-tests.yaml
@@ -89,6 +89,11 @@ spec:
             fi
           fi
 
+          echo ""
+          echo "📋 Manual curl command:"
+          echo "curl --fail -k -s --show-error --request GET -H 'Authorization: Basic <AUTH_KEY>' ${RESOLVE_OPT} 'https://${HOST}${ENDPOINT_PATH}'"
+          echo ""
+
           POD_NAME="curl-test-$(date +%s)-${RANDOM}"
           echo "======== Sending request to https://${HOST}${ENDPOINT_PATH} via remote pod ========"
           RESULT=$(oc run "${POD_NAME}" -n default --rm -i --restart=Never \
@@ -104,6 +109,20 @@ spec:
           echo "${RESULT}"
           echo "✅ Endpoint succeeded: ${ENDPOINT_PATH}"
         else
+          RESOLVE_OPT=""
+          if [[ "$(params.publicDNS)" != "true" ]]; then
+            if [[ "$INGRESS_IP" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              RESOLVE_OPT="--resolve ${HOST}:443:${INGRESS_IP}"
+            else
+              RESOLVE_OPT="--connect-to ${HOST}:443:${INGRESS_IP}:443"
+            fi
+          fi
+
+          echo ""
+          echo "📋 Manual curl command:"
+          echo "curl --fail -k -s --show-error --request GET -H 'Authorization: Basic <AUTH_KEY>' ${RESOLVE_OPT} 'https://${HOST}${ENDPOINT_PATH}'"
+          echo ""
+
           TEST_SCRIPT="./edge-integration-cell/test_eic_endpoints.sh"
 
           SCRIPT_ARGS=("--host" "$HOST")

--- a/.tekton/tasks/hcp-deploy-dashboards-task.yaml
+++ b/.tekton/tasks/hcp-deploy-dashboards-task.yaml
@@ -1,0 +1,319 @@
+# SPDX-FileCopyrightText: 2025 SAP edge team
+# SPDX-FileContributor: Manjun Jiao (@mjiao)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: hcp-deploy-dashboards
+spec:
+  description: >-
+    Deploys Perses dashboards on the hosted cluster using the Cluster
+    Observability Operator (COO). Sets up the Monitoring UIPlugin, creates
+    a PersesDatasource pointing to the platform Thanos Querier, and applies
+    the community Istio dashboards from the perses/community-mixins project.
+  params:
+    - name: hostedClusterName
+      type: string
+      description: "Name of the hosted cluster"
+    - name: hostedClusterNamespace
+      type: string
+      description: "Namespace for HostedCluster resources"
+      default: "clusters"
+    - name: hubKubeconfigSecretName
+      type: string
+      description: "Name of the Secret containing kubeconfig for hub cluster (optional, uses in-cluster config if empty)"
+      default: ""
+  workspaces:
+    - name: source
+  steps:
+    - name: deploy-dashboards
+      image: registry.access.redhat.com/ubi9/ubi
+      timeout: "30m"
+      workingDir: $(workspaces.source.path)
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        CLUSTER_NAME="$(params.hostedClusterName)"
+        CLUSTER_NS="$(params.hostedClusterNamespace)"
+        HUB_KUBECONFIG_SECRET="$(params.hubKubeconfigSecretName)"
+
+        echo "=========================================="
+        echo "HCP Deploy Dashboards Task"
+        echo "=========================================="
+        echo "Hosted Cluster: ${CLUSTER_NAME}"
+        echo "=========================================="
+
+        # Install required tools
+        echo "📦 Installing required packages..."
+        dnf install -y jq > /dev/null 2>&1
+
+        echo "📦 Installing OpenShift CLI..."
+        curl -sL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz -o /tmp/oc.tar.gz
+        tar xzf /tmp/oc.tar.gz -C /tmp
+        mv /tmp/oc /usr/local/bin/
+        cp /usr/local/bin/oc /usr/local/bin/kubectl
+        rm -f /tmp/oc.tar.gz
+        oc version --client
+
+        # Configure hub cluster kubeconfig if provided
+        if [[ -n "${HUB_KUBECONFIG_SECRET}" ]]; then
+          echo "🔐 Extracting hub cluster kubeconfig from secret: ${HUB_KUBECONFIG_SECRET}..."
+          HUB_KUBECONFIG="/tmp/hub-kubeconfig"
+          if kubectl get secret "${HUB_KUBECONFIG_SECRET}" -o jsonpath='{.data.kubeconfig}' 2>/dev/null | base64 -d > "${HUB_KUBECONFIG}" 2>/dev/null && [[ -s "${HUB_KUBECONFIG}" ]]; then
+            echo "✅ Kubeconfig extracted (key: kubeconfig)"
+          elif kubectl get secret "${HUB_KUBECONFIG_SECRET}" -o jsonpath='{.data.config}' 2>/dev/null | base64 -d > "${HUB_KUBECONFIG}" 2>/dev/null && [[ -s "${HUB_KUBECONFIG}" ]]; then
+            echo "✅ Kubeconfig extracted (key: config)"
+          elif kubectl get secret "${HUB_KUBECONFIG_SECRET}" -o jsonpath='{.data.value}' 2>/dev/null | base64 -d > "${HUB_KUBECONFIG}" 2>/dev/null && [[ -s "${HUB_KUBECONFIG}" ]]; then
+            echo "✅ Kubeconfig extracted (key: value)"
+          else
+            echo "❌ Failed to extract kubeconfig from secret '${HUB_KUBECONFIG_SECRET}'"
+            exit 1
+          fi
+          chmod 600 "${HUB_KUBECONFIG}"
+          export KUBECONFIG="${HUB_KUBECONFIG}"
+          echo "✅ Using hub kubeconfig for cluster operations"
+          oc whoami
+        else
+          echo "ℹ️  No hub kubeconfig secret provided, using in-cluster service account"
+        fi
+
+        # Extract hosted cluster kubeconfig
+        echo ""
+        echo "🔐 Extracting kubeconfig for hosted cluster..."
+        HOSTED_KUBECONFIG="/tmp/hosted-kubeconfig"
+        kubectl get secret "${CLUSTER_NAME}-admin-kubeconfig" -n "${CLUSTER_NS}" \
+          -o jsonpath='{.data.kubeconfig}' | base64 -d > "${HOSTED_KUBECONFIG}"
+        chmod 600 "${HOSTED_KUBECONFIG}"
+        export KUBECONFIG="${HOSTED_KUBECONFIG}"
+        [[ -f "$(workspaces.source.path)/.kubeconfig-rewrite.sh" ]] && source "$(workspaces.source.path)/.kubeconfig-rewrite.sh" "${HOSTED_KUBECONFIG}"
+        echo "✅ Successfully connected to hosted cluster"
+        oc whoami
+
+        # =============================================
+        # Step 1: Install Cluster Observability Operator (idempotent)
+        # =============================================
+        echo ""
+        echo "📦 Step 1: Installing Cluster Observability Operator..."
+
+        COO_CHANNEL=$(oc get packagemanifest cluster-observability-operator -o jsonpath='{.status.defaultChannel}' 2>/dev/null || echo "")
+        if [[ -z "${COO_CHANNEL}" ]]; then
+          echo "❌ Cluster Observability Operator not available in catalog"
+          echo "   Cannot deploy Perses dashboards without COO"
+          exit 1
+        fi
+
+        echo "   Using channel: ${COO_CHANNEL}"
+
+        oc apply -f - <<EOF
+        apiVersion: operators.coreos.com/v1alpha1
+        kind: Subscription
+        metadata:
+          name: cluster-observability-operator
+          namespace: openshift-operators
+        spec:
+          channel: ${COO_CHANNEL}
+          installPlanApproval: Automatic
+          name: cluster-observability-operator
+          source: redhat-operators
+          sourceNamespace: openshift-marketplace
+        EOF
+
+        echo "⏳ Waiting for Cluster Observability Operator CSV to succeed..."
+        COO_CSV=""
+        for i in $(seq 1 60); do
+          COO_CSV=$(oc get csv -n openshift-operators -l operators.coreos.com/cluster-observability-operator.openshift-operators -o jsonpath='{.items[0].status.phase}' 2>/dev/null || echo "")
+          if [[ "${COO_CSV}" == "Succeeded" ]]; then
+            echo "✅ Cluster Observability Operator installed successfully"
+            break
+          fi
+          if [[ ${i} -eq 60 ]]; then
+            echo "❌ Timeout waiting for Cluster Observability Operator (current phase: ${COO_CSV})"
+            exit 1
+          fi
+          echo "   [${i}/60] COO CSV phase: ${COO_CSV:-Pending}"
+          sleep 10
+        done
+
+        # =============================================
+        # Step 2: Enable the Perses UIPlugin (Monitoring type)
+        # =============================================
+        echo ""
+        echo "🖥️  Step 2: Enabling Perses UIPlugin (Monitoring)..."
+
+        UIPLUGIN_APPLIED=false
+        for API_VERSION in "observability.openshift.io/v1alpha1" "observability.openshift.io/v1"; do
+          if oc api-resources --api-group=observability.openshift.io 2>/dev/null | grep -q "UIPlugin"; then
+            if oc apply -f - <<EOF 2>/dev/null
+        apiVersion: ${API_VERSION}
+        kind: UIPlugin
+        metadata:
+          name: monitoring
+        spec:
+          type: Monitoring
+          monitoring:
+            perses:
+              enabled: true
+        EOF
+            then
+              UIPLUGIN_APPLIED=true
+              echo "✅ UIPlugin 'monitoring' created (${API_VERSION})"
+              break
+            fi
+          fi
+        done
+
+        if [[ "${UIPLUGIN_APPLIED}" != "true" ]]; then
+          echo "❌ UIPlugin CRD not available — cannot enable Perses dashboards"
+          exit 1
+        fi
+
+        echo "⏳ Waiting for UIPlugin to reconcile..."
+        for i in $(seq 1 30); do
+          RECONCILED=$(oc get uiplugin monitoring -o jsonpath='{range .status.conditions[*]}{.type}={.status}{"\n"}{end}' 2>/dev/null | grep -c "=True" || echo "0")
+          if [[ "${RECONCILED}" -ge 1 ]]; then
+            echo "✅ UIPlugin reconciled"
+            oc get uiplugin monitoring -o jsonpath='{range .status.conditions[*]}{.type}={.status}{"\n"}{end}' 2>/dev/null || true
+            break
+          fi
+          if [[ ${i} -eq 30 ]]; then
+            echo "⚠️  UIPlugin not fully reconciled yet — continuing anyway"
+          fi
+          echo "   [${i}/30] Waiting for UIPlugin conditions..."
+          sleep 10
+        done
+
+        # =============================================
+        # Step 3: Create perses-dev namespace and ServiceAccount
+        # =============================================
+        echo ""
+        echo "📂 Step 3: Setting up perses-dev namespace and ServiceAccount..."
+
+        oc create namespace perses-dev --dry-run=client -o yaml | oc apply -f -
+
+        oc create serviceaccount perses-sa -n perses-dev --dry-run=client -o yaml | oc apply -f -
+
+        oc adm policy add-cluster-role-to-user cluster-monitoring-view -z perses-sa -n perses-dev
+        echo "✅ ServiceAccount 'perses-sa' created and cluster-monitoring-view role bound"
+
+        # =============================================
+        # Step 4: Create bearer token secret for Thanos Querier
+        # =============================================
+        echo ""
+        echo "🔐 Step 4: Creating bearer token secret for Thanos Querier..."
+
+        TOKEN=$(oc create token perses-sa -n perses-dev --duration=8760h)
+
+        oc apply -f - <<EOF
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: prometheus-datasource-secret
+          namespace: perses-dev
+        stringData:
+          Authorization: "Bearer ${TOKEN}"
+        type: Opaque
+        EOF
+
+        echo "✅ Token secret 'prometheus-datasource-secret' created (valid for 1 year)"
+
+        # =============================================
+        # Step 5: Create PersesDatasource
+        # =============================================
+        echo ""
+        echo "📊 Step 5: Creating PersesDatasource..."
+
+        oc apply -f - <<EOF
+        apiVersion: perses.dev/v1alpha1
+        kind: PersesDatasource
+        metadata:
+          name: prometheus-datasource
+          namespace: perses-dev
+        spec:
+          config:
+            display:
+              name: "Thanos Querier Datasource"
+            default: true
+            plugin:
+              kind: "PrometheusDatasource"
+              spec:
+                proxy:
+                  kind: HTTPProxy
+                  spec:
+                    url: https://thanos-querier.openshift-monitoring.svc.cluster.local:9091
+                    secret: prometheus-datasource-secret
+          client:
+            tls:
+              enable: true
+              caCert:
+                type: file
+                certPath: /ca/service-ca.crt
+        EOF
+
+        echo "✅ PersesDatasource 'prometheus-datasource' created"
+
+        # =============================================
+        # Step 6: Apply community Istio dashboards
+        # =============================================
+        echo ""
+        echo "📊 Step 6: Applying community Istio dashboards..."
+
+        MIXIN_BASE="https://raw.githubusercontent.com/perses/community-mixins/refs/heads/main/examples/dashboards/operator/istio"
+
+        DASHBOARDS=(
+          "istio-mesh.yaml"
+          "istio-service-dashboard.yaml"
+          "istio-workload-dashboard.yaml"
+          "istio-control-plane.yaml"
+          "istio-performance.yaml"
+          "istio-ztunnel-dashboard.yaml"
+        )
+
+        APPLIED=0
+        FAILED=0
+        for DASHBOARD in "${DASHBOARDS[@]}"; do
+          echo "   Applying ${DASHBOARD}..."
+          if oc apply -f "${MIXIN_BASE}/${DASHBOARD}" 2>/dev/null; then
+            APPLIED=$((APPLIED + 1))
+            echo "   ✅ ${DASHBOARD}"
+          else
+            FAILED=$((FAILED + 1))
+            echo "   ⚠️  Failed to apply ${DASHBOARD}"
+          fi
+        done
+
+        echo ""
+        echo "📊 Dashboards applied: ${APPLIED}/${#DASHBOARDS[@]}"
+        if [[ ${FAILED} -gt 0 ]]; then
+          echo "⚠️  ${FAILED} dashboard(s) failed to apply"
+        fi
+
+        # =============================================
+        # Step 7: Verification
+        # =============================================
+        echo ""
+        echo "🔍 Step 7: Verifying Perses deployment..."
+
+        echo ""
+        echo "📋 UIPlugin status:"
+        oc get uiplugin monitoring 2>/dev/null || echo "   UIPlugin not found"
+
+        echo ""
+        echo "📋 PersesDatasource:"
+        oc get persesdatasource -n perses-dev 2>/dev/null || echo "   No PersesDatasource found"
+
+        echo ""
+        echo "📋 PersesDashboards:"
+        oc get persesdashboard -n perses-dev 2>/dev/null || echo "   No PersesDashboard found"
+
+        echo ""
+        echo "=========================================="
+        echo "✅ Perses dashboards deployed successfully!"
+        echo "=========================================="
+        echo "UIPlugin: monitoring (type: Monitoring)"
+        echo "Datasource: prometheus-datasource (Thanos Querier)"
+        echo "Dashboards: ${APPLIED} Istio community dashboards"
+        echo "Console: Observe → Dashboards (Perses)"
+        echo "=========================================="

--- a/.tekton/tasks/hcp-deploy-logging-task.yaml
+++ b/.tekton/tasks/hcp-deploy-logging-task.yaml
@@ -1,0 +1,606 @@
+# SPDX-FileCopyrightText: 2025 SAP edge team
+# SPDX-FileContributor: Manjun Jiao (@mjiao)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: hcp-deploy-logging
+spec:
+  description: Deploy LokiStack logging on the hosted cluster with OBC-backed S3 storage from the hub
+  params:
+    - name: hostedClusterName
+      type: string
+      description: "Name of the hosted cluster"
+    - name: hostedClusterNamespace
+      type: string
+      description: "Namespace for HostedCluster resources"
+      default: "clusters"
+    - name: hubKubeconfigSecretName
+      type: string
+      description: "Name of the Secret containing kubeconfig for hub cluster (optional, uses in-cluster config if empty)"
+      default: ""
+    - name: lokiSize
+      type: string
+      description: "LokiStack size (1x.extra-small for test/validation, 1x.small for production)"
+      default: "1x.extra-small"
+    - name: storageClassName
+      type: string
+      description: "StorageClass for LokiStack PVCs (auto-detected if empty)"
+      default: ""
+  workspaces:
+    - name: source
+  steps:
+    - name: deploy-logging
+      image: registry.access.redhat.com/ubi9/ubi
+      timeout: "336h"
+      workingDir: $(workspaces.source.path)
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        # Parameters
+        CLUSTER_NAME="$(params.hostedClusterName)"
+        CLUSTER_NS="$(params.hostedClusterNamespace)"
+        HUB_KUBECONFIG_SECRET="$(params.hubKubeconfigSecretName)"
+        LOKI_SIZE="$(params.lokiSize)"
+        STORAGE_CLASS="$(params.storageClassName)"
+
+        echo "=========================================="
+        echo "HCP Deploy Logging Task"
+        echo "=========================================="
+        echo "Hosted Cluster: ${CLUSTER_NAME}"
+        echo "Cluster Namespace: ${CLUSTER_NS}"
+        echo "LokiStack Size: ${LOKI_SIZE}"
+        echo "StorageClass: ${STORAGE_CLASS:-auto-detect}"
+        echo "=========================================="
+
+        # Install required tools
+        echo "📦 Installing required packages..."
+        dnf install -y jq > /dev/null 2>&1
+
+        echo "📦 Installing OpenShift CLI..."
+        curl -sL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz -o /tmp/oc.tar.gz
+        tar xzf /tmp/oc.tar.gz -C /tmp
+        mv /tmp/oc /usr/local/bin/
+        cp /usr/local/bin/oc /usr/local/bin/kubectl
+        rm -f /tmp/oc.tar.gz
+        oc version --client
+
+        # Configure hub cluster kubeconfig if provided
+        if [[ -n "${HUB_KUBECONFIG_SECRET}" ]]; then
+          echo "🔐 Extracting hub cluster kubeconfig from secret: ${HUB_KUBECONFIG_SECRET}..."
+          HUB_KUBECONFIG="/tmp/hub-kubeconfig"
+          if kubectl get secret "${HUB_KUBECONFIG_SECRET}" -o jsonpath='{.data.kubeconfig}' 2>/dev/null | base64 -d > "${HUB_KUBECONFIG}" 2>/dev/null && [[ -s "${HUB_KUBECONFIG}" ]]; then
+            echo "✅ Kubeconfig extracted (key: kubeconfig)"
+          elif kubectl get secret "${HUB_KUBECONFIG_SECRET}" -o jsonpath='{.data.config}' 2>/dev/null | base64 -d > "${HUB_KUBECONFIG}" 2>/dev/null && [[ -s "${HUB_KUBECONFIG}" ]]; then
+            echo "✅ Kubeconfig extracted (key: config)"
+          elif kubectl get secret "${HUB_KUBECONFIG_SECRET}" -o jsonpath='{.data.value}' 2>/dev/null | base64 -d > "${HUB_KUBECONFIG}" 2>/dev/null && [[ -s "${HUB_KUBECONFIG}" ]]; then
+            echo "✅ Kubeconfig extracted (key: value)"
+          else
+            echo "❌ Failed to extract kubeconfig from secret '${HUB_KUBECONFIG_SECRET}'"
+            echo "   Secret should have kubeconfig data under key 'kubeconfig', 'config', or 'value'"
+            exit 1
+          fi
+          chmod 600 "${HUB_KUBECONFIG}"
+          export KUBECONFIG="${HUB_KUBECONFIG}"
+          echo "✅ Using hub kubeconfig for cluster operations"
+          oc whoami
+        else
+          echo "ℹ️  No hub kubeconfig secret provided, using in-cluster service account"
+        fi
+
+        # =============================================
+        # Step 1: Create per-cluster OBC on hub for Loki S3 storage
+        # =============================================
+        OBC_NAME="loki-${CLUSTER_NAME}"
+        OBC_NAMESPACE="openshift-storage"
+
+        echo ""
+        echo "📦 Creating ObjectBucketClaim '${OBC_NAME}' on hub cluster..."
+
+        oc apply -f - <<EOF
+        apiVersion: objectbucket.io/v1alpha1
+        kind: ObjectBucketClaim
+        metadata:
+          name: ${OBC_NAME}
+          namespace: ${OBC_NAMESPACE}
+          labels:
+            app: loki-logging
+            cluster: ${CLUSTER_NAME}
+        spec:
+          generateBucketName: ${OBC_NAME}
+          storageClassName: openshift-storage.noobaa.io
+        EOF
+
+        echo "⏳ Waiting for OBC to become Bound..."
+        for i in $(seq 1 60); do
+          OBC_PHASE=$(oc get objectbucketclaim "${OBC_NAME}" -n "${OBC_NAMESPACE}" -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+          if [[ "${OBC_PHASE}" == "Bound" ]]; then
+            echo "✅ OBC is Bound"
+            break
+          fi
+          if [[ ${i} -eq 60 ]]; then
+            echo "❌ Timeout waiting for OBC to become Bound (current phase: ${OBC_PHASE})"
+            exit 1
+          fi
+          echo "   [${i}/60] OBC phase: ${OBC_PHASE:-Pending}"
+          sleep 10
+        done
+
+        # Extract S3 credentials from OBC-generated Secret and ConfigMap
+        echo "🔐 Extracting S3 credentials from OBC..."
+        S3_ACCESS_KEY=$(oc get secret "${OBC_NAME}" -n "${OBC_NAMESPACE}" -o jsonpath='{.data.AWS_ACCESS_KEY_ID}' | base64 -d)
+        S3_SECRET_KEY=$(oc get secret "${OBC_NAME}" -n "${OBC_NAMESPACE}" -o jsonpath='{.data.AWS_SECRET_ACCESS_KEY}' | base64 -d)
+        S3_BUCKET_NAME=$(oc get configmap "${OBC_NAME}" -n "${OBC_NAMESPACE}" -o jsonpath='{.data.BUCKET_NAME}')
+
+        # Use the external S3 route (not the internal svc) since LokiStack
+        # runs on the hosted cluster and can't reach hub-internal services
+        S3_ROUTE_HOST=$(oc get route s3 -n openshift-storage -o jsonpath='{.spec.host}' 2>/dev/null || echo "")
+        if [[ -z "${S3_ROUTE_HOST}" ]]; then
+          echo "❌ Could not find S3 route in openshift-storage namespace"
+          echo "   Available routes:"
+          oc get route -n openshift-storage 2>/dev/null || echo "   None found"
+          exit 1
+        fi
+        S3_ENDPOINT="https://${S3_ROUTE_HOST}"
+
+        echo "✅ S3 credentials extracted"
+        echo "   Endpoint: ${S3_ENDPOINT} (external route)"
+        echo "   Bucket: ${S3_BUCKET_NAME}"
+        echo "   Access Key: ${S3_ACCESS_KEY:0:4}****"
+
+        # Extract hub ingress CA so the hosted cluster can trust the S3 route TLS cert
+        echo "🔐 Extracting hub ingress CA certificate..."
+        HUB_CA_CERT="/tmp/hub-ingress-ca.crt"
+        oc get secret router-certs-default -n openshift-ingress \
+          -o jsonpath='{.data.tls\.crt}' 2>/dev/null | base64 -d > "${HUB_CA_CERT}" || true
+        if [[ ! -s "${HUB_CA_CERT}" ]]; then
+          # Fall back to the default ingress controller CA
+          oc get configmap default-ingress-cert -n openshift-config-managed \
+            -o jsonpath='{.data.ca-bundle\.crt}' > "${HUB_CA_CERT}" 2>/dev/null || true
+        fi
+        if [[ -s "${HUB_CA_CERT}" ]]; then
+          echo "✅ Hub ingress CA extracted"
+        else
+          echo "⚠️  Could not extract hub ingress CA — LokiStack may fail TLS to S3 route"
+        fi
+
+        # =============================================
+        # Step 2: Switch to hosted cluster kubeconfig
+        # =============================================
+        echo ""
+        echo "🔐 Extracting kubeconfig for hosted cluster..."
+        KUBECONFIG_SECRET="${CLUSTER_NAME}-admin-kubeconfig"
+
+        if ! oc get secret "${KUBECONFIG_SECRET}" -n "${CLUSTER_NS}" > /dev/null 2>&1; then
+          echo "❌ Kubeconfig secret '${KUBECONFIG_SECRET}' not found in namespace '${CLUSTER_NS}'"
+          exit 1
+        fi
+
+        HOSTED_KUBECONFIG="/tmp/hosted-kubeconfig"
+        oc get secret "${KUBECONFIG_SECRET}" -n "${CLUSTER_NS}" \
+          -o jsonpath='{.data.kubeconfig}' | base64 -d > "${HOSTED_KUBECONFIG}"
+        chmod 600 "${HOSTED_KUBECONFIG}"
+
+        export KUBECONFIG="${HOSTED_KUBECONFIG}"
+        [[ -f "$(workspaces.source.path)/.kubeconfig-rewrite.sh" ]] && source "$(workspaces.source.path)/.kubeconfig-rewrite.sh" "${HOSTED_KUBECONFIG}"
+
+        echo "🔍 Verifying access to hosted cluster..."
+        oc get nodes
+        echo "✅ Successfully connected to hosted cluster"
+
+        # =============================================
+        # Step 3: Create openshift-logging namespace
+        # =============================================
+        echo ""
+        echo "📂 Ensuring openshift-logging namespace exists..."
+        oc create namespace openshift-logging --dry-run=client -o yaml | oc apply -f -
+
+        # Also ensure openshift-operators-redhat namespace for Loki Operator
+        echo "📂 Ensuring openshift-operators-redhat namespace exists..."
+        oc create namespace openshift-operators-redhat --dry-run=client -o yaml | oc apply -f -
+
+        # Create CA ConfigMap for S3 route TLS trust (if we extracted the hub CA)
+        LOKI_CA_NAME=""
+        if [[ -s "${HUB_CA_CERT}" ]]; then
+          echo "🔐 Creating CA ConfigMap for S3 storage TLS trust..."
+          oc create configmap loki-s3-ca \
+            --from-file=service-ca.crt="${HUB_CA_CERT}" \
+            -n openshift-logging --dry-run=client -o yaml | oc apply -f -
+          LOKI_CA_NAME="loki-s3-ca"
+          echo "✅ CA ConfigMap 'loki-s3-ca' created in openshift-logging"
+        fi
+
+        # =============================================
+        # Step 4: Install Loki Operator
+        # =============================================
+        echo ""
+        echo "📦 Installing Loki Operator..."
+
+        # Auto-detect the default channel from the PackageManifest
+        LOKI_CHANNEL=$(oc get packagemanifest loki-operator -o jsonpath='{.status.defaultChannel}' 2>/dev/null || echo "")
+        AVAILABLE_CHANNELS=$(oc get packagemanifest loki-operator -o jsonpath='{.status.channels[*].name}' 2>/dev/null || echo "")
+        echo "   defaultChannel: '${LOKI_CHANNEL}', available: '${AVAILABLE_CHANNELS}'"
+
+        # Prefer the latest stable-* channel; fall back to defaultChannel if none exist
+        STABLE_CHANNEL=$(echo "${AVAILABLE_CHANNELS}" | tr ' ' '\n' | grep '^stable-' | sort -rV | head -1 || true)
+        if [[ -n "${STABLE_CHANNEL}" ]]; then
+          LOKI_CHANNEL="${STABLE_CHANNEL}"
+        elif [[ -z "${LOKI_CHANNEL}" ]]; then
+          echo "❌ No channel found for loki-operator (available: ${AVAILABLE_CHANNELS})"
+          exit 1
+        else
+          echo "⚠️  No stable-* channel available — using defaultChannel '${LOKI_CHANNEL}'"
+        fi
+        echo "   Using channel: ${LOKI_CHANNEL}"
+
+        # Create OperatorGroup for openshift-operators-redhat if needed
+        if ! oc get operatorgroup -n openshift-operators-redhat --no-headers 2>/dev/null | grep -q .; then
+          oc apply -f - <<EOF
+        apiVersion: operators.coreos.com/v1
+        kind: OperatorGroup
+        metadata:
+          name: openshift-operators-redhat
+          namespace: openshift-operators-redhat
+        spec: {}
+        EOF
+        fi
+
+        oc apply -f - <<EOF
+        apiVersion: operators.coreos.com/v1alpha1
+        kind: Subscription
+        metadata:
+          name: loki-operator
+          namespace: openshift-operators-redhat
+        spec:
+          channel: ${LOKI_CHANNEL}
+          installPlanApproval: Automatic
+          name: loki-operator
+          source: redhat-operators
+          sourceNamespace: openshift-marketplace
+        EOF
+
+        echo "⏳ Waiting for Loki Operator CSV to succeed..."
+        for i in $(seq 1 60); do
+          LOKI_CSV=$(oc get csv -n openshift-operators-redhat -l operators.coreos.com/loki-operator.openshift-operators-redhat -o jsonpath='{.items[0].status.phase}' 2>/dev/null || echo "")
+          if [[ "${LOKI_CSV}" == "Succeeded" ]]; then
+            echo "✅ Loki Operator installed successfully"
+            break
+          fi
+          if [[ ${i} -eq 60 ]]; then
+            echo "❌ Timeout waiting for Loki Operator (current phase: ${LOKI_CSV})"
+            exit 1
+          fi
+          echo "   [${i}/60] Loki Operator CSV phase: ${LOKI_CSV:-Pending}"
+          sleep 10
+        done
+
+        # =============================================
+        # Step 5: Install Red Hat OpenShift Logging Operator
+        # =============================================
+        echo ""
+        echo "📦 Installing Red Hat OpenShift Logging Operator..."
+
+        # Auto-detect the default channel from the PackageManifest
+        LOGGING_CHANNEL=$(oc get packagemanifest cluster-logging -o jsonpath='{.status.defaultChannel}' 2>/dev/null || echo "")
+        if [[ -z "${LOGGING_CHANNEL}" ]]; then
+          echo "❌ Could not detect Logging Operator channel from PackageManifest"
+          echo "   Available packagemanifests:"
+          oc get packagemanifest 2>/dev/null | grep -i logging || echo "   None found"
+          exit 1
+        fi
+        echo "   Using channel: ${LOGGING_CHANNEL}"
+
+        # Create OperatorGroup for openshift-logging if needed
+        if ! oc get operatorgroup -n openshift-logging --no-headers 2>/dev/null | grep -q .; then
+          oc apply -f - <<EOF
+        apiVersion: operators.coreos.com/v1
+        kind: OperatorGroup
+        metadata:
+          name: openshift-logging
+          namespace: openshift-logging
+        spec:
+          targetNamespaces:
+            - openshift-logging
+        EOF
+        fi
+
+        oc apply -f - <<EOF
+        apiVersion: operators.coreos.com/v1alpha1
+        kind: Subscription
+        metadata:
+          name: cluster-logging
+          namespace: openshift-logging
+        spec:
+          channel: ${LOGGING_CHANNEL}
+          installPlanApproval: Automatic
+          name: cluster-logging
+          source: redhat-operators
+          sourceNamespace: openshift-marketplace
+        EOF
+
+        echo "⏳ Waiting for OpenShift Logging Operator CSV to succeed..."
+        for i in $(seq 1 60); do
+          LOGGING_CSV=$(oc get csv -n openshift-logging -l operators.coreos.com/cluster-logging.openshift-logging -o jsonpath='{.items[0].status.phase}' 2>/dev/null || echo "")
+          if [[ "${LOGGING_CSV}" == "Succeeded" ]]; then
+            echo "✅ OpenShift Logging Operator installed successfully"
+            break
+          fi
+          if [[ ${i} -eq 60 ]]; then
+            echo "❌ Timeout waiting for OpenShift Logging Operator (current phase: ${LOGGING_CSV})"
+            exit 1
+          fi
+          echo "   [${i}/60] Logging Operator CSV phase: ${LOGGING_CSV:-Pending}"
+          sleep 10
+        done
+
+        # =============================================
+        # Step 6: Create S3 Secret for LokiStack (KBA Step 1)
+        # =============================================
+        echo ""
+        echo "🔐 Creating S3 storage secret for LokiStack..."
+
+        oc apply -f - <<EOF
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: logging-loki-s3
+          namespace: openshift-logging
+        stringData:
+          endpoint: "${S3_ENDPOINT}"
+          bucketnames: "${S3_BUCKET_NAME}"
+          access_key_id: "${S3_ACCESS_KEY}"
+          access_key_secret: "${S3_SECRET_KEY}"
+        type: Opaque
+        EOF
+
+        echo "✅ S3 storage secret created"
+
+        # =============================================
+        # Step 7: Deploy LokiStack (KBA Step 2)
+        # =============================================
+        echo ""
+        echo "📦 Deploying LokiStack (size: ${LOKI_SIZE})..."
+
+        # Auto-detect StorageClass if not provided
+        if [[ -z "${STORAGE_CLASS}" ]]; then
+          STORAGE_CLASS=$(oc get sc -o jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")].metadata.name}' 2>/dev/null || echo "")
+          if [[ -z "${STORAGE_CLASS}" ]]; then
+            STORAGE_CLASS=$(oc get sc -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "gp3-csi")
+          fi
+          echo "   Auto-detected StorageClass: ${STORAGE_CLASS}"
+        fi
+
+        # Build LokiStack manifest with optional TLS CA reference
+        LOKISTACK_YAML=$(cat <<EOYAML
+        apiVersion: loki.grafana.com/v1
+        kind: LokiStack
+        metadata:
+          name: logging-loki
+          namespace: openshift-logging
+        spec:
+          size: ${LOKI_SIZE}
+          storage:
+            schemas:
+            - version: v13
+              effectiveDate: "2024-10-25"
+            secret:
+              name: logging-loki-s3
+              type: s3
+        EOYAML
+        )
+
+        if [[ -n "${LOKI_CA_NAME}" ]]; then
+          LOKISTACK_YAML+="
+            tls:
+              caName: ${LOKI_CA_NAME}"
+        fi
+
+        LOKISTACK_YAML+="
+          storageClassName: ${STORAGE_CLASS}
+          tenants:
+            mode: openshift-logging"
+
+        echo "${LOKISTACK_YAML}" | oc apply -f -
+
+        echo "⏳ Waiting for LokiStack pods to be running..."
+        for i in $(seq 1 90); do
+          READY_PODS=$(oc get pods -n openshift-logging -l app.kubernetes.io/instance=logging-loki --no-headers 2>/dev/null | grep -c "Running" || true)
+          TOTAL_PODS=$(oc get pods -n openshift-logging -l app.kubernetes.io/instance=logging-loki --no-headers 2>/dev/null | wc -l | tr -d ' ')
+          if [[ "${TOTAL_PODS}" -gt 0 && "${READY_PODS}" -eq "${TOTAL_PODS}" ]]; then
+            echo "✅ All LokiStack pods are running (${READY_PODS}/${TOTAL_PODS})"
+            break
+          fi
+          if [[ ${i} -eq 90 ]]; then
+            echo "⚠️  Timeout waiting for all LokiStack pods (${READY_PODS}/${TOTAL_PODS} running)"
+            echo "   Continuing anyway — pods may still be starting up"
+            oc get pods -n openshift-logging -l app.kubernetes.io/instance=logging-loki
+          fi
+          echo "   [${i}/90] LokiStack pods: ${READY_PODS}/${TOTAL_PODS} running"
+          sleep 10
+        done
+
+        # =============================================
+        # Step 8: Create Log Collector ServiceAccount (KBA Step 3)
+        # =============================================
+        echo ""
+        echo "👤 Creating log collector ServiceAccount..."
+
+        oc create sa eic-log-collector -n openshift-logging --dry-run=client -o yaml | oc apply -f -
+
+        oc adm policy add-cluster-role-to-user collect-application-logs \
+          -z eic-log-collector -n openshift-logging
+
+        oc adm policy add-cluster-role-to-user cluster-logging-write-application-logs \
+          -z eic-log-collector -n openshift-logging
+
+        echo "✅ ServiceAccount created and roles bound"
+
+        # =============================================
+        # Step 9: Deploy ClusterLogForwarder (KBA Step 4)
+        # =============================================
+        echo ""
+        echo "📋 Deploying ClusterLogForwarder for EIC namespaces..."
+
+        oc apply -f - <<EOF
+        apiVersion: observability.openshift.io/v1
+        kind: ClusterLogForwarder
+        metadata:
+          name: eic-log-collector
+          namespace: openshift-logging
+        spec:
+          serviceAccount:
+            name: eic-log-collector
+          inputs:
+          - name: eic-application-logs
+            type: application
+            application:
+              includes:
+              - namespace: edgelm
+              - namespace: edge-icell
+              - namespace: edge-icell-services
+              - namespace: edge-icell-secrets
+              - namespace: edge-icell-ela
+              - namespace: istio-gateways
+          outputs:
+          - name: loki-output
+            type: lokiStack
+            lokiStack:
+              target:
+                name: logging-loki
+                namespace: openshift-logging
+              dataModel: Otel
+              authentication:
+                token:
+                  from: serviceAccount
+            tls:
+              ca:
+                configMapName: logging-loki-gateway-ca-bundle
+                key: service-ca.crt
+          pipelines:
+          - name: eic-logs-pipeline
+            inputRefs:
+            - eic-application-logs
+            outputRefs:
+            - loki-output
+        EOF
+
+        echo "✅ ClusterLogForwarder deployed"
+
+        # =============================================
+        # Step 10: Install Cluster Observability Operator (for UIPlugin CRD)
+        # =============================================
+        echo ""
+        echo "📦 Installing Cluster Observability Operator..."
+
+        COO_CHANNEL=$(oc get packagemanifest cluster-observability-operator -o jsonpath='{.status.defaultChannel}' 2>/dev/null || echo "")
+        if [[ -z "${COO_CHANNEL}" ]]; then
+          echo "⚠️  Cluster Observability Operator not available in catalog — skipping UIPlugin"
+        else
+          echo "   Using channel: ${COO_CHANNEL}"
+
+          oc apply -f - <<EOF
+        apiVersion: operators.coreos.com/v1alpha1
+        kind: Subscription
+        metadata:
+          name: cluster-observability-operator
+          namespace: openshift-operators
+        spec:
+          channel: ${COO_CHANNEL}
+          installPlanApproval: Automatic
+          name: cluster-observability-operator
+          source: redhat-operators
+          sourceNamespace: openshift-marketplace
+        EOF
+
+          echo "⏳ Waiting for Cluster Observability Operator CSV to succeed..."
+          for i in $(seq 1 60); do
+            COO_CSV=$(oc get csv -n openshift-operators -l operators.coreos.com/cluster-observability-operator.openshift-operators -o jsonpath='{.items[0].status.phase}' 2>/dev/null || echo "")
+            if [[ "${COO_CSV}" == "Succeeded" ]]; then
+              echo "✅ Cluster Observability Operator installed successfully"
+              break
+            fi
+            if [[ ${i} -eq 60 ]]; then
+              echo "⚠️  Timeout waiting for Cluster Observability Operator — skipping UIPlugin"
+              break
+            fi
+            echo "   [${i}/60] COO CSV phase: ${COO_CSV:-Pending}"
+            sleep 10
+          done
+
+          # =============================================
+          # Step 11: Enable Console Log Viewer (KBA Step 5)
+          # =============================================
+          if [[ "${COO_CSV}" == "Succeeded" ]]; then
+            echo ""
+            echo "🖥️  Enabling console log viewer (UIPlugin)..."
+
+            UIPLUGIN_APPLIED=false
+            for API_VERSION in "observability.openshift.io/v1alpha1" "observability.openshift.io/v1"; do
+              if oc api-resources --api-group=observability.openshift.io 2>/dev/null | grep -q "UIPlugin"; then
+                if oc apply -f - <<EOF 2>/dev/null
+        apiVersion: ${API_VERSION}
+        kind: UIPlugin
+        metadata:
+          name: logging
+        spec:
+          type: Logging
+          logging:
+            lokiStack:
+              name: logging-loki
+        EOF
+                then
+                  UIPLUGIN_APPLIED=true
+                  echo "✅ UIPlugin created (${API_VERSION}) — Observe → Logs will be available after console refresh"
+                  break
+                fi
+              fi
+            done
+
+            if [[ "${UIPLUGIN_APPLIED}" != "true" ]]; then
+              echo "⚠️  UIPlugin CRD not available — skipping console log viewer"
+              echo "   Logs can still be queried via the Loki API directly"
+            fi
+          fi
+        fi
+
+        # =============================================
+        # Step 11: Verification
+        # =============================================
+        echo ""
+        echo "🔍 Verifying logging stack deployment..."
+        echo ""
+
+        echo "📋 Operator CSVs:"
+        oc get csv -n openshift-operators-redhat 2>/dev/null | grep -i loki || echo "   No Loki CSV found"
+        oc get csv -n openshift-logging 2>/dev/null | grep -i logging || echo "   No Logging CSV found"
+
+        echo ""
+        echo "📋 LokiStack status:"
+        oc get lokistack logging-loki -n openshift-logging 2>/dev/null || echo "   LokiStack not found"
+
+        echo ""
+        echo "📋 LokiStack pods:"
+        oc get pods -n openshift-logging -l app.kubernetes.io/instance=logging-loki --no-headers 2>/dev/null || echo "   No LokiStack pods"
+
+        echo ""
+        echo "📋 Log collector pods:"
+        oc get pods -n openshift-logging -l app.kubernetes.io/instance=eic-log-collector --no-headers 2>/dev/null || echo "   No collector pods yet (may take a moment to start)"
+
+        echo ""
+        echo "📋 ClusterLogForwarder conditions:"
+        oc get clusterlogforwarder eic-log-collector -n openshift-logging -o yaml 2>/dev/null | grep -A 5 conditions || echo "   No conditions available yet"
+
+        echo ""
+        echo "=========================================="
+        echo "✅ Logging stack deployed successfully!"
+        echo "=========================================="
+        echo "OBC: ${OBC_NAME} (hub cluster, namespace: ${OBC_NAMESPACE})"
+        echo "S3 Bucket: ${S3_BUCKET_NAME}"
+        echo "LokiStack Size: ${LOKI_SIZE}"
+        echo "StorageClass: ${STORAGE_CLASS}"
+        echo "Collecting logs from: edgelm, edge-icell, edge-icell-services, edge-icell-secrets, edge-icell-ela, istio-gateways"
+        echo "Console: Observe → Logs (after refresh)"
+        echo "=========================================="

--- a/.tekton/tasks/hcp-deploy-tracing-task.yaml
+++ b/.tekton/tasks/hcp-deploy-tracing-task.yaml
@@ -1,0 +1,800 @@
+# SPDX-FileCopyrightText: 2025 SAP edge team
+# SPDX-FileContributor: Manjun Jiao (@mjiao)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: hcp-deploy-tracing
+spec:
+  description: Deploy distributed tracing (TempoStack, OpenTelemetry, Kiali) on the hosted cluster with OBC-backed S3 storage from the hub
+  params:
+    - name: hostedClusterName
+      type: string
+      description: "Name of the hosted cluster"
+    - name: hostedClusterNamespace
+      type: string
+      description: "Namespace for HostedCluster resources"
+      default: "clusters"
+    - name: hubKubeconfigSecretName
+      type: string
+      description: "Name of the Secret containing kubeconfig for hub cluster (optional, uses in-cluster config if empty)"
+      default: ""
+    - name: istioNamespace
+      type: string
+      description: "Namespace where Istio control plane and OTel collector are deployed"
+      default: "istio-system"
+    - name: istioCRName
+      type: string
+      description: "Name of the Istio CR to patch with tracing extension providers"
+      default: "default"
+  workspaces:
+    - name: source
+  steps:
+    - name: deploy-tracing
+      image: registry.access.redhat.com/ubi9/ubi
+      timeout: "336h"
+      workingDir: $(workspaces.source.path)
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        # Parameters
+        CLUSTER_NAME="$(params.hostedClusterName)"
+        CLUSTER_NS="$(params.hostedClusterNamespace)"
+        HUB_KUBECONFIG_SECRET="$(params.hubKubeconfigSecretName)"
+        ISTIO_NS="$(params.istioNamespace)"
+        ISTIO_CR_NAME="$(params.istioCRName)"
+
+        echo "=========================================="
+        echo "HCP Deploy Tracing Task"
+        echo "=========================================="
+        echo "Hosted Cluster: ${CLUSTER_NAME}"
+        echo "Cluster Namespace: ${CLUSTER_NS}"
+        echo "Istio Namespace: ${ISTIO_NS}"
+        echo "Istio CR Name: ${ISTIO_CR_NAME}"
+        echo "=========================================="
+
+        # Install required tools
+        echo "📦 Installing required packages..."
+        dnf install -y jq > /dev/null 2>&1
+
+        echo "📦 Installing OpenShift CLI..."
+        curl -sL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz -o /tmp/oc.tar.gz
+        tar xzf /tmp/oc.tar.gz -C /tmp
+        mv /tmp/oc /usr/local/bin/
+        cp /usr/local/bin/oc /usr/local/bin/kubectl
+        rm -f /tmp/oc.tar.gz
+        oc version --client
+
+        # Configure hub cluster kubeconfig if provided
+        if [[ -n "${HUB_KUBECONFIG_SECRET}" ]]; then
+          echo "🔐 Extracting hub cluster kubeconfig from secret: ${HUB_KUBECONFIG_SECRET}..."
+          HUB_KUBECONFIG="/tmp/hub-kubeconfig"
+          if kubectl get secret "${HUB_KUBECONFIG_SECRET}" -o jsonpath='{.data.kubeconfig}' 2>/dev/null | base64 -d > "${HUB_KUBECONFIG}" 2>/dev/null && [[ -s "${HUB_KUBECONFIG}" ]]; then
+            echo "✅ Kubeconfig extracted (key: kubeconfig)"
+          elif kubectl get secret "${HUB_KUBECONFIG_SECRET}" -o jsonpath='{.data.config}' 2>/dev/null | base64 -d > "${HUB_KUBECONFIG}" 2>/dev/null && [[ -s "${HUB_KUBECONFIG}" ]]; then
+            echo "✅ Kubeconfig extracted (key: config)"
+          elif kubectl get secret "${HUB_KUBECONFIG_SECRET}" -o jsonpath='{.data.value}' 2>/dev/null | base64 -d > "${HUB_KUBECONFIG}" 2>/dev/null && [[ -s "${HUB_KUBECONFIG}" ]]; then
+            echo "✅ Kubeconfig extracted (key: value)"
+          else
+            echo "❌ Failed to extract kubeconfig from secret '${HUB_KUBECONFIG_SECRET}'"
+            echo "   Secret should have kubeconfig data under key 'kubeconfig', 'config', or 'value'"
+            exit 1
+          fi
+          chmod 600 "${HUB_KUBECONFIG}"
+          export KUBECONFIG="${HUB_KUBECONFIG}"
+          echo "✅ Using hub kubeconfig for cluster operations"
+          oc whoami
+        else
+          echo "ℹ️  No hub kubeconfig secret provided, using in-cluster service account"
+        fi
+
+        # =============================================
+        # Step 1: Create per-cluster OBC on hub for Tempo S3 storage
+        # =============================================
+        OBC_NAME="tempo-${CLUSTER_NAME}"
+        OBC_NAMESPACE="openshift-storage"
+
+        echo ""
+        echo "📦 Creating ObjectBucketClaim '${OBC_NAME}' on hub cluster..."
+
+        oc apply -f - <<EOF
+        apiVersion: objectbucket.io/v1alpha1
+        kind: ObjectBucketClaim
+        metadata:
+          name: ${OBC_NAME}
+          namespace: ${OBC_NAMESPACE}
+          labels:
+            app: tempo-tracing
+            cluster: ${CLUSTER_NAME}
+        spec:
+          generateBucketName: ${OBC_NAME}
+          storageClassName: openshift-storage.noobaa.io
+        EOF
+
+        echo "⏳ Waiting for OBC to become Bound..."
+        for i in $(seq 1 60); do
+          OBC_PHASE=$(oc get objectbucketclaim "${OBC_NAME}" -n "${OBC_NAMESPACE}" -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+          if [[ "${OBC_PHASE}" == "Bound" ]]; then
+            echo "✅ OBC is Bound"
+            break
+          fi
+          if [[ ${i} -eq 60 ]]; then
+            echo "❌ Timeout waiting for OBC to become Bound (current phase: ${OBC_PHASE})"
+            exit 1
+          fi
+          echo "   [${i}/60] OBC phase: ${OBC_PHASE:-Pending}"
+          sleep 10
+        done
+
+        # Extract S3 credentials from OBC-generated Secret and ConfigMap
+        echo "🔐 Extracting S3 credentials from OBC..."
+        S3_ACCESS_KEY=$(oc get secret "${OBC_NAME}" -n "${OBC_NAMESPACE}" -o jsonpath='{.data.AWS_ACCESS_KEY_ID}' | base64 -d)
+        S3_SECRET_KEY=$(oc get secret "${OBC_NAME}" -n "${OBC_NAMESPACE}" -o jsonpath='{.data.AWS_SECRET_ACCESS_KEY}' | base64 -d)
+        S3_BUCKET_NAME=$(oc get configmap "${OBC_NAME}" -n "${OBC_NAMESPACE}" -o jsonpath='{.data.BUCKET_NAME}')
+
+        # Use the external S3 route (not the internal svc) since TempoStack
+        # runs on the hosted cluster and can't reach hub-internal services
+        S3_ROUTE_HOST=$(oc get route s3 -n openshift-storage -o jsonpath='{.spec.host}' 2>/dev/null || echo "")
+        if [[ -z "${S3_ROUTE_HOST}" ]]; then
+          echo "❌ Could not find S3 route in openshift-storage namespace"
+          echo "   Available routes:"
+          oc get route -n openshift-storage 2>/dev/null || echo "   None found"
+          exit 1
+        fi
+        S3_ENDPOINT="https://${S3_ROUTE_HOST}"
+
+        echo "✅ S3 credentials extracted"
+        echo "   Endpoint: ${S3_ENDPOINT} (external route)"
+        echo "   Bucket: ${S3_BUCKET_NAME}"
+        echo "   Access Key: ${S3_ACCESS_KEY:0:4}****"
+
+        # Extract hub ingress CA so the hosted cluster can trust the S3 route TLS cert
+        echo "🔐 Extracting hub ingress CA certificate..."
+        HUB_CA_CERT="/tmp/hub-ingress-ca.crt"
+        oc get secret router-certs-default -n openshift-ingress \
+          -o jsonpath='{.data.tls\.crt}' 2>/dev/null | base64 -d > "${HUB_CA_CERT}" || true
+        if [[ ! -s "${HUB_CA_CERT}" ]]; then
+          oc get configmap default-ingress-cert -n openshift-config-managed \
+            -o jsonpath='{.data.ca-bundle\.crt}' > "${HUB_CA_CERT}" 2>/dev/null || true
+        fi
+        if [[ -s "${HUB_CA_CERT}" ]]; then
+          echo "✅ Hub ingress CA extracted"
+        else
+          echo "⚠️  Could not extract hub ingress CA — TempoStack may fail TLS to S3 route"
+        fi
+
+        # =============================================
+        # Step 2: Switch to hosted cluster kubeconfig
+        # =============================================
+        echo ""
+        echo "🔐 Extracting kubeconfig for hosted cluster..."
+        KUBECONFIG_SECRET="${CLUSTER_NAME}-admin-kubeconfig"
+
+        if ! oc get secret "${KUBECONFIG_SECRET}" -n "${CLUSTER_NS}" > /dev/null 2>&1; then
+          echo "❌ Kubeconfig secret '${KUBECONFIG_SECRET}' not found in namespace '${CLUSTER_NS}'"
+          exit 1
+        fi
+
+        HOSTED_KUBECONFIG="/tmp/hosted-kubeconfig"
+        oc get secret "${KUBECONFIG_SECRET}" -n "${CLUSTER_NS}" \
+          -o jsonpath='{.data.kubeconfig}' | base64 -d > "${HOSTED_KUBECONFIG}"
+        chmod 600 "${HOSTED_KUBECONFIG}"
+
+        export KUBECONFIG="${HOSTED_KUBECONFIG}"
+        [[ -f "$(workspaces.source.path)/.kubeconfig-rewrite.sh" ]] && source "$(workspaces.source.path)/.kubeconfig-rewrite.sh" "${HOSTED_KUBECONFIG}"
+
+        echo "🔍 Verifying access to hosted cluster..."
+        oc get nodes
+        echo "✅ Successfully connected to hosted cluster"
+
+        # =============================================
+        # Step 3: Create tempo namespace and CA ConfigMap
+        # =============================================
+        echo ""
+        echo "📂 Creating tempo namespace..."
+        oc create namespace tempo --dry-run=client -o yaml | oc apply -f -
+
+        TEMPO_CA_NAME=""
+        if [[ -s "${HUB_CA_CERT}" ]]; then
+          echo "🔐 Creating CA ConfigMap for S3 storage TLS trust..."
+          oc create configmap tempo-s3-ca \
+            --from-file=service-ca.crt="${HUB_CA_CERT}" \
+            -n tempo --dry-run=client -o yaml | oc apply -f -
+          TEMPO_CA_NAME="tempo-s3-ca"
+          echo "✅ CA ConfigMap 'tempo-s3-ca' created in tempo namespace"
+        fi
+
+        # =============================================
+        # Step 4: Install Tempo Operator
+        # =============================================
+        echo ""
+        echo "📦 Installing Tempo Operator..."
+
+        TEMPO_CHANNEL=$(oc get packagemanifest tempo-product -o jsonpath='{.status.defaultChannel}' 2>/dev/null || echo "")
+        if [[ -z "${TEMPO_CHANNEL}" ]]; then
+          echo "❌ Could not detect Tempo Operator channel from PackageManifest"
+          oc get packagemanifest 2>/dev/null | grep -i tempo || echo "   None found"
+          exit 1
+        fi
+        echo "   Using channel: ${TEMPO_CHANNEL}"
+
+        oc create namespace openshift-tempo-operator --dry-run=client -o yaml | oc apply -f -
+
+        if ! oc get operatorgroup -n openshift-tempo-operator --no-headers 2>/dev/null | grep -q .; then
+          oc apply -f - <<EOF
+        apiVersion: operators.coreos.com/v1
+        kind: OperatorGroup
+        metadata:
+          name: openshift-tempo-operator
+          namespace: openshift-tempo-operator
+        spec: {}
+        EOF
+        fi
+
+        oc apply -f - <<EOF
+        apiVersion: operators.coreos.com/v1alpha1
+        kind: Subscription
+        metadata:
+          name: tempo-product
+          namespace: openshift-tempo-operator
+        spec:
+          channel: ${TEMPO_CHANNEL}
+          installPlanApproval: Automatic
+          name: tempo-product
+          source: redhat-operators
+          sourceNamespace: openshift-marketplace
+        EOF
+
+        echo "⏳ Waiting for Tempo Operator CSV to succeed..."
+        for i in $(seq 1 60); do
+          TEMPO_CSV=$(oc get csv -n openshift-tempo-operator -l operators.coreos.com/tempo-product.openshift-tempo-operator -o jsonpath='{.items[0].status.phase}' 2>/dev/null || echo "")
+          if [[ "${TEMPO_CSV}" == "Succeeded" ]]; then
+            echo "✅ Tempo Operator installed successfully"
+            break
+          fi
+          if [[ ${i} -eq 60 ]]; then
+            echo "❌ Timeout waiting for Tempo Operator (current phase: ${TEMPO_CSV})"
+            exit 1
+          fi
+          echo "   [${i}/60] Tempo Operator CSV phase: ${TEMPO_CSV:-Pending}"
+          sleep 10
+        done
+
+        # =============================================
+        # Step 5: Install OpenTelemetry Operator
+        # =============================================
+        echo ""
+        echo "📦 Installing OpenTelemetry Operator..."
+
+        OTEL_CHANNEL=$(oc get packagemanifest opentelemetry-product -o jsonpath='{.status.defaultChannel}' 2>/dev/null || echo "")
+        if [[ -z "${OTEL_CHANNEL}" ]]; then
+          echo "❌ Could not detect OpenTelemetry Operator channel from PackageManifest"
+          oc get packagemanifest 2>/dev/null | grep -i opentelemetry || echo "   None found"
+          exit 1
+        fi
+        echo "   Using channel: ${OTEL_CHANNEL}"
+
+        oc create namespace openshift-opentelemetry-operator --dry-run=client -o yaml | oc apply -f -
+
+        if ! oc get operatorgroup -n openshift-opentelemetry-operator --no-headers 2>/dev/null | grep -q .; then
+          oc apply -f - <<EOF
+        apiVersion: operators.coreos.com/v1
+        kind: OperatorGroup
+        metadata:
+          name: openshift-opentelemetry-operator
+          namespace: openshift-opentelemetry-operator
+        spec: {}
+        EOF
+        fi
+
+        oc apply -f - <<EOF
+        apiVersion: operators.coreos.com/v1alpha1
+        kind: Subscription
+        metadata:
+          name: opentelemetry-product
+          namespace: openshift-opentelemetry-operator
+        spec:
+          channel: ${OTEL_CHANNEL}
+          installPlanApproval: Automatic
+          name: opentelemetry-product
+          source: redhat-operators
+          sourceNamespace: openshift-marketplace
+        EOF
+
+        echo "⏳ Waiting for OpenTelemetry Operator CSV to succeed..."
+        for i in $(seq 1 60); do
+          OTEL_CSV=$(oc get csv -n openshift-opentelemetry-operator -l operators.coreos.com/opentelemetry-product.openshift-opentelemetry-operator -o jsonpath='{.items[0].status.phase}' 2>/dev/null || echo "")
+          if [[ "${OTEL_CSV}" == "Succeeded" ]]; then
+            echo "✅ OpenTelemetry Operator installed successfully"
+            break
+          fi
+          if [[ ${i} -eq 60 ]]; then
+            echo "❌ Timeout waiting for OpenTelemetry Operator (current phase: ${OTEL_CSV})"
+            exit 1
+          fi
+          echo "   [${i}/60] OpenTelemetry Operator CSV phase: ${OTEL_CSV:-Pending}"
+          sleep 10
+        done
+
+        # =============================================
+        # Step 6: Install Kiali Operator
+        # =============================================
+        echo ""
+        echo "📦 Installing Kiali Operator..."
+
+        KIALI_CHANNEL=$(oc get packagemanifest kiali-ossm -o jsonpath='{.status.defaultChannel}' 2>/dev/null || echo "")
+        if [[ -z "${KIALI_CHANNEL}" ]]; then
+          echo "❌ Could not detect Kiali Operator channel from PackageManifest"
+          oc get packagemanifest 2>/dev/null | grep -i kiali || echo "   None found"
+          exit 1
+        fi
+        echo "   Using channel: ${KIALI_CHANNEL}"
+
+        oc apply -f - <<EOF
+        apiVersion: operators.coreos.com/v1alpha1
+        kind: Subscription
+        metadata:
+          name: kiali-ossm
+          namespace: openshift-operators
+        spec:
+          channel: ${KIALI_CHANNEL}
+          installPlanApproval: Automatic
+          name: kiali-ossm
+          source: redhat-operators
+          sourceNamespace: openshift-marketplace
+        EOF
+
+        echo "⏳ Waiting for Kiali Operator CSV to succeed..."
+        for i in $(seq 1 60); do
+          KIALI_CSV=$(oc get csv -n openshift-operators -l operators.coreos.com/kiali-ossm.openshift-operators -o jsonpath='{.items[0].status.phase}' 2>/dev/null || echo "")
+          if [[ "${KIALI_CSV}" == "Succeeded" ]]; then
+            echo "✅ Kiali Operator installed successfully"
+            break
+          fi
+          if [[ ${i} -eq 60 ]]; then
+            echo "❌ Timeout waiting for Kiali Operator (current phase: ${KIALI_CSV})"
+            exit 1
+          fi
+          echo "   [${i}/60] Kiali Operator CSV phase: ${KIALI_CSV:-Pending}"
+          sleep 10
+        done
+
+        # =============================================
+        # Step 7: Create S3 Secret and Deploy TempoStack (KBA Step 1)
+        # =============================================
+        echo ""
+        echo "🔐 Creating S3 storage secret for TempoStack..."
+
+        oc apply -f - <<EOF
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: tempo-storage-s3
+          namespace: tempo
+        stringData:
+          bucket: "${S3_BUCKET_NAME}"
+          endpoint: "${S3_ENDPOINT}"
+          access_key_id: "${S3_ACCESS_KEY}"
+          access_key_secret: "${S3_SECRET_KEY}"
+        type: Opaque
+        EOF
+
+        echo "✅ S3 storage secret created"
+
+        echo ""
+        echo "📦 Deploying TempoStack..."
+
+        TEMPOSTACK_YAML=$(cat <<EOYAML
+        apiVersion: tempo.grafana.com/v1alpha1
+        kind: TempoStack
+        metadata:
+          name: sample
+          namespace: tempo
+        spec:
+          managementState: Managed
+          tenants:
+            mode: openshift
+            authentication:
+            - tenantName: dev
+              tenantId: dev
+          template:
+            gateway:
+              enabled: true
+            queryFrontend:
+              jaegerQuery:
+                enabled: true
+          storage:
+            secret:
+              name: tempo-storage-s3
+              type: s3
+        EOYAML
+        )
+
+        if [[ -n "${TEMPO_CA_NAME}" ]]; then
+          TEMPOSTACK_YAML+="
+            tls:
+              caName: ${TEMPO_CA_NAME}"
+        fi
+
+        echo "${TEMPOSTACK_YAML}" | oc apply -f -
+
+        echo "⏳ Waiting for TempoStack pods to be running..."
+        for i in $(seq 1 90); do
+          READY_PODS=$(oc get pods -n tempo -l app.kubernetes.io/instance=sample --no-headers 2>/dev/null | grep -c "Running" || true)
+          TOTAL_PODS=$(oc get pods -n tempo -l app.kubernetes.io/instance=sample --no-headers 2>/dev/null | wc -l | tr -d ' ')
+          if [[ "${TOTAL_PODS}" -gt 0 && "${READY_PODS}" -eq "${TOTAL_PODS}" ]]; then
+            echo "✅ All TempoStack pods are running (${READY_PODS}/${TOTAL_PODS})"
+            break
+          fi
+          if [[ ${i} -eq 90 ]]; then
+            echo "⚠️  Timeout waiting for all TempoStack pods (${READY_PODS}/${TOTAL_PODS} running)"
+            echo "   Continuing anyway — pods may still be starting up"
+            oc get pods -n tempo -l app.kubernetes.io/instance=sample
+          fi
+          echo "   [${i}/90] TempoStack pods: ${READY_PODS}/${TOTAL_PODS} running"
+          sleep 10
+        done
+
+        # =============================================
+        # Step 8: Configure trace access RBAC (KBA Step 1 cont.)
+        # =============================================
+        echo ""
+        echo "🔐 Configuring trace access RBAC..."
+
+        oc apply -f - <<EOF
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRole
+        metadata:
+          name: tempostack-traces-reader
+        rules:
+        - apiGroups:
+          - tempo.grafana.com
+          resources:
+          - dev
+          resourceNames:
+          - traces
+          verbs:
+          - get
+        ---
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRoleBinding
+        metadata:
+          name: tempostack-traces-reader
+        roleRef:
+          apiGroup: rbac.authorization.k8s.io
+          kind: ClusterRole
+          name: tempostack-traces-reader
+        subjects:
+        - kind: Group
+          apiGroup: rbac.authorization.k8s.io
+          name: system:authenticated
+        ---
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRole
+        metadata:
+          name: tempostack-traces-write
+        rules:
+        - apiGroups:
+          - tempo.grafana.com
+          resources:
+          - dev
+          resourceNames:
+          - traces
+          verbs:
+          - create
+        ---
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRoleBinding
+        metadata:
+          name: tempostack-traces-write
+        roleRef:
+          apiGroup: rbac.authorization.k8s.io
+          kind: ClusterRole
+          name: tempostack-traces-write
+        subjects:
+        - kind: ServiceAccount
+          name: otel-collector
+          namespace: ${ISTIO_NS}
+        EOF
+
+        echo "✅ Trace access RBAC configured"
+
+        # =============================================
+        # Step 9: Deploy OpenTelemetry Collector (KBA Step 2)
+        # =============================================
+        echo ""
+        echo "📡 Deploying OpenTelemetry Collector in ${ISTIO_NS}..."
+
+        oc apply -f - <<EOF
+        kind: OpenTelemetryCollector
+        apiVersion: opentelemetry.io/v1beta1
+        metadata:
+          name: otel
+          namespace: ${ISTIO_NS}
+        spec:
+          observability:
+            metrics: {}
+          deploymentUpdateStrategy: {}
+          config:
+            exporters:
+              otlp:
+                endpoint: tempo-sample-gateway.tempo.svc.cluster.local:8090
+                tls:
+                  insecure: false
+                  ca_file: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+                auth:
+                  authenticator: bearertokenauth
+                headers:
+                  X-Scope-OrgID: dev
+            extensions:
+              bearertokenauth:
+                filename: /var/run/secrets/kubernetes.io/serviceaccount/token
+            receivers:
+              otlp:
+                protocols:
+                  grpc:
+                    endpoint: 0.0.0.0:4317
+                  http: {}
+            service:
+              extensions:
+              - bearertokenauth
+              pipelines:
+                traces:
+                  exporters:
+                  - otlp
+                  receivers:
+                  - otlp
+        EOF
+
+        echo "⏳ Waiting for OTel Collector pod to be running..."
+        for i in $(seq 1 60); do
+          OTEL_PODS=$(oc get pods -n "${ISTIO_NS}" -l app.kubernetes.io/name=otel-collector --no-headers 2>/dev/null | grep -c "Running" || true)
+          if [[ "${OTEL_PODS}" -gt 0 ]]; then
+            echo "✅ OTel Collector pod is running"
+            break
+          fi
+          if [[ ${i} -eq 60 ]]; then
+            echo "⚠️  Timeout waiting for OTel Collector pod"
+            oc get pods -n "${ISTIO_NS}" -l app.kubernetes.io/name=otel-collector 2>/dev/null || true
+          fi
+          echo "   [${i}/60] Waiting for OTel Collector..."
+          sleep 10
+        done
+
+        # =============================================
+        # Step 10: Disable mTLS for OTel collector (no sidecar)
+        # =============================================
+        echo ""
+        echo "🔒 Creating DestinationRule to disable mTLS for OTel collector..."
+
+        oc apply -f - <<EOF
+        apiVersion: networking.istio.io/v1
+        kind: DestinationRule
+        metadata:
+          name: otel-collector-disable-mtls
+          namespace: ${ISTIO_NS}
+        spec:
+          host: otel-collector.${ISTIO_NS}.svc.cluster.local
+          trafficPolicy:
+            tls:
+              mode: DISABLE
+        EOF
+
+        echo "✅ DestinationRule created — mesh sidecars will use plaintext gRPC to OTel collector"
+
+        # =============================================
+        # Step 11: Patch Istio CR with tracing provider (KBA Step 3)
+        # =============================================
+        echo ""
+        echo "🔧 Patching Istio CR '${ISTIO_CR_NAME}' with tracing extension provider..."
+
+        oc patch istio "${ISTIO_CR_NAME}" -n "${ISTIO_NS}" --type merge -p "
+        spec:
+          values:
+            meshConfig:
+              extensionProviders:
+                - name: otel-tracing
+                  opentelemetry:
+                    port: 4317
+                    service: otel-collector.${ISTIO_NS}.svc.cluster.local
+        "
+
+        echo "✅ Istio CR patched"
+
+        echo "📋 Creating Telemetry resource..."
+
+        oc apply -f - <<EOF
+        apiVersion: telemetry.istio.io/v1
+        kind: Telemetry
+        metadata:
+          name: otel-tracing
+          namespace: ${ISTIO_NS}
+        spec:
+          tracing:
+          - providers:
+            - name: otel-tracing
+            randomSamplingPercentage: 100
+        EOF
+
+        echo "✅ Telemetry resource created (100% sampling)"
+
+        # =============================================
+        # Step 12: Deploy Kiali (KBA Step 4)
+        # =============================================
+        echo ""
+        echo "🔐 Creating Kiali monitoring RBAC..."
+
+        oc apply -f - <<EOF
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRoleBinding
+        metadata:
+          name: kiali-monitoring-rbac
+        roleRef:
+          apiGroup: rbac.authorization.k8s.io
+          kind: ClusterRole
+          name: cluster-monitoring-view
+        subjects:
+        - kind: ServiceAccount
+          name: kiali-service-account
+          namespace: ${ISTIO_NS}
+        EOF
+
+        echo "✅ Kiali monitoring RBAC created"
+
+        echo ""
+        echo "📦 Deploying Kiali CR..."
+
+        TEMPO_ROUTE_HOST=$(oc get route tempo-sample-gateway -n tempo -o jsonpath='{.spec.host}' 2>/dev/null || echo "")
+
+        oc apply -f - <<EOF
+        apiVersion: kiali.io/v1alpha1
+        kind: Kiali
+        metadata:
+          name: kiali
+          namespace: ${ISTIO_NS}
+        spec:
+          external_services:
+            prometheus:
+              auth:
+                ca_file: /kiali-cabundle/service-ca.crt
+                insecure_skip_verify: false
+                type: bearer
+                use_kiali_token: true
+              thanos_proxy:
+                enabled: true
+              url: https://thanos-querier.openshift-monitoring.svc.cluster.local:9091
+            tracing:
+              enabled: true
+              provider: tempo
+              use_grpc: false
+              internal_url: https://tempo-sample-gateway.tempo.svc.cluster.local:8080/api/traces/v1/dev/tempo
+              auth:
+                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+                insecure_skip_verify: false
+                type: bearer
+                use_kiali_token: true
+              tempo_config:
+                url_format: jaeger
+        EOF
+
+        if [[ -n "${TEMPO_ROUTE_HOST}" ]]; then
+          echo "🔗 Setting Tempo external URL for 'View in Tracing' link..."
+          oc patch kiali kiali -n "${ISTIO_NS}" --type merge -p "
+        spec:
+          external_services:
+            tracing:
+              url: https://${TEMPO_ROUTE_HOST}/api/traces/v1/dev
+        "
+          echo "✅ Tempo external URL: https://${TEMPO_ROUTE_HOST}/api/traces/v1/dev"
+        else
+          echo "⚠️  Tempo gateway route not found — 'View in Tracing' link will not work"
+        fi
+
+        echo "⏳ Waiting for Kiali pod to be running..."
+        for i in $(seq 1 60); do
+          KIALI_PODS=$(oc get pods -n "${ISTIO_NS}" -l app.kubernetes.io/name=kiali --no-headers 2>/dev/null | grep -c "Running" || true)
+          if [[ "${KIALI_PODS}" -gt 0 ]]; then
+            echo "✅ Kiali pod is running"
+            break
+          fi
+          if [[ ${i} -eq 60 ]]; then
+            echo "⚠️  Timeout waiting for Kiali pod"
+            oc get pods -n "${ISTIO_NS}" -l app.kubernetes.io/name=kiali 2>/dev/null || true
+          fi
+          echo "   [${i}/60] Waiting for Kiali..."
+          sleep 10
+        done
+
+        # =============================================
+        # Step 13: Deploy OSSMC Plugin (KBA Step 5)
+        # =============================================
+        echo ""
+        echo "🖥️  Deploying OpenShift Service Mesh Console plugin..."
+
+        oc apply -f - <<EOF
+        apiVersion: kiali.io/v1alpha1
+        kind: OSSMConsole
+        metadata:
+          name: ossmconsole
+          namespace: ${ISTIO_NS}
+        spec:
+          kiali:
+            serviceName: kiali
+            serviceNamespace: ${ISTIO_NS}
+        EOF
+
+        echo "⏳ Waiting for OSSMC plugin to reconcile..."
+        for i in $(seq 1 60); do
+          OSSMC_STATUS=$(oc get ossmconsole ossmconsole -n "${ISTIO_NS}" -o jsonpath='{.status.conditions[?(@.type=="Successful")].status}' 2>/dev/null || echo "")
+          if [[ "${OSSMC_STATUS}" == "True" ]]; then
+            echo "✅ OSSMC plugin reconciled — Service Mesh menu available in console"
+            break
+          fi
+          if [[ ${i} -eq 60 ]]; then
+            echo "⚠️  Timeout waiting for OSSMC plugin reconciliation"
+            oc get ossmconsole ossmconsole -n "${ISTIO_NS}" -o yaml 2>/dev/null | grep -A 5 conditions || true
+          fi
+          echo "   [${i}/60] OSSMC status: ${OSSMC_STATUS:-Pending}"
+          sleep 10
+        done
+
+        # =============================================
+        # Step 14: Verification
+        # =============================================
+        echo ""
+        echo "🔍 Verifying tracing stack deployment..."
+        echo ""
+
+        echo "📋 Operator CSVs:"
+        oc get csv -n openshift-tempo-operator 2>/dev/null | grep -i tempo || echo "   No Tempo CSV found"
+        oc get csv -n openshift-opentelemetry-operator 2>/dev/null | grep -i opentelemetry || echo "   No OpenTelemetry CSV found"
+        oc get csv -n openshift-operators 2>/dev/null | grep -i kiali || echo "   No Kiali CSV found"
+
+        echo ""
+        echo "📋 TempoStack pods:"
+        oc get pods -n tempo -l app.kubernetes.io/instance=sample --no-headers 2>/dev/null || echo "   No TempoStack pods"
+
+        echo ""
+        echo "📋 OTel Collector pods:"
+        oc get pods -n "${ISTIO_NS}" -l app.kubernetes.io/name=otel-collector --no-headers 2>/dev/null || echo "   No OTel Collector pods"
+
+        echo ""
+        echo "📋 Kiali pods:"
+        oc get pods -n "${ISTIO_NS}" -l app.kubernetes.io/name=kiali --no-headers 2>/dev/null || echo "   No Kiali pods"
+
+        echo ""
+        echo "📋 Kiali route:"
+        KIALI_URL=$(oc get route kiali -n "${ISTIO_NS}" -o jsonpath='{.spec.host}' 2>/dev/null || echo "")
+        if [[ -n "${KIALI_URL}" ]]; then
+          echo "   https://${KIALI_URL}"
+        else
+          echo "   No Kiali route found"
+        fi
+
+        echo ""
+        echo "📋 Istio extensionProviders:"
+        oc get istio "${ISTIO_CR_NAME}" -n "${ISTIO_NS}" -o jsonpath='{.spec.values.meshConfig.extensionProviders}' 2>/dev/null || echo "   Not configured"
+
+        echo ""
+        echo "📋 Telemetry resource:"
+        oc get telemetry otel-tracing -n "${ISTIO_NS}" 2>/dev/null || echo "   Not found"
+
+        echo ""
+        echo "📋 OSSMC plugin:"
+        oc get ossmconsole ossmconsole -n "${ISTIO_NS}" 2>/dev/null || echo "   Not found"
+
+        echo ""
+        echo "=========================================="
+        echo "✅ Tracing stack deployed successfully!"
+        echo "=========================================="
+        echo "OBC: tempo-${CLUSTER_NAME} (hub cluster, namespace: openshift-storage)"
+        echo "S3 Bucket: ${S3_BUCKET_NAME}"
+        echo "TempoStack: sample (namespace: tempo)"
+        echo "OTel Collector: otel (namespace: ${ISTIO_NS})"
+        echo "Kiali UI: https://${KIALI_URL:-<pending>}"
+        echo "OSSMC: Service Mesh menu in OpenShift console"
+        echo "Sampling: 100% (adjust Telemetry resource for production)"
+        echo "=========================================="

--- a/.tekton/tasks/hcp-enable-monitoring-task.yaml
+++ b/.tekton/tasks/hcp-enable-monitoring-task.yaml
@@ -9,12 +9,11 @@ metadata:
   name: hcp-enable-monitoring
 spec:
   description: >-
-    Enables User Workload Monitoring (UWM) on the hosted cluster.
-    This must run before EIC deployment so that ServiceMonitors created by
-    EIC are picked up by Prometheus immediately. NetworkPolicies for
-    Prometheus scraping are created later in the verify-monitoring task
-    to avoid breaking intra-namespace traffic before SAP ELM deploys
-    its own NetworkPolicies.
+    Enables User Workload Monitoring (UWM) on the hosted cluster and
+    creates NetworkPolicies to allow Prometheus scraping in EIC namespaces.
+    Runs before EIC deployment so that ServiceMonitors created by EIC
+    are picked up by Prometheus immediately and scraping works as soon
+    as pods start.
   params:
     - name: hostedClusterName
       type: string
@@ -135,9 +134,63 @@ spec:
           sleep 10
         done
 
+        # Step 2: Create NetworkPolicies for Prometheus scraping
+        echo ""
+        echo "🔒 Step 2: Creating NetworkPolicies for Prometheus scraping..."
+
+        NAMESPACES=("edge-icell" "edge-icell-services" "edgelm")
+
+        for NS in "${NAMESPACES[@]}"; do
+          if oc get namespace "${NS}" &>/dev/null; then
+            echo "📦 Creating NetworkPolicies in ${NS}..."
+            cat <<EONP | oc apply -f -
+        apiVersion: networking.k8s.io/v1
+        kind: NetworkPolicy
+        metadata:
+          name: allow-from-openshift-user-workload-monitoring
+          namespace: ${NS}
+        spec:
+          podSelector: {}
+          ingress:
+          - from:
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: openshift-user-workload-monitoring
+        ---
+        apiVersion: networking.k8s.io/v1
+        kind: NetworkPolicy
+        metadata:
+          name: allow-same-namespace
+          namespace: ${NS}
+        spec:
+          podSelector: {}
+          ingress:
+          - from:
+            - podSelector: {}
+        ---
+        apiVersion: networking.k8s.io/v1
+        kind: NetworkPolicy
+        metadata:
+          name: allow-from-edgelm-product-namespaces
+          namespace: ${NS}
+        spec:
+          podSelector: {}
+          ingress:
+          - from:
+            - namespaceSelector:
+                matchLabels:
+                  edgelm.sap.com/product: edgelm
+        EONP
+            echo "✅ NetworkPolicies created in ${NS}"
+          else
+            echo "ℹ️  Namespace ${NS} does not exist, skipping NetworkPolicies"
+          fi
+        done
+
         echo ""
         echo "=========================================="
         echo "✅ Monitoring Setup Complete"
         echo "=========================================="
         echo "  UWM: Enabled"
+        echo "  NetworkPolicies: Created in ${NAMESPACES[*]}"
         echo "=========================================="

--- a/.tekton/tasks/hcp-fix-endpointslice-task.yaml
+++ b/.tekton/tasks/hcp-fix-endpointslice-task.yaml
@@ -9,11 +9,15 @@ metadata:
   name: hcp-fix-endpointslice
 spec:
   description: >-
-    Workaround for Hypershift KubeVirt bug on OpenShift 4.21 where the
-    service-sync controller fails to create EndpointSlice objects for
-    LoadBalancer services in the guest cluster, breaking MetalLB ingress
-    routing. Checks if EndpointSlices exist for the management service
-    and creates them manually if missing.
+    Workaround for HyperShift KubeVirt EndpointSlice bugs affecting MetalLB
+    ingress routing. On OCP 4.21, the control-plane-operator failed to create
+    EndpointSlices at all; on OCP 4.22+, it creates them but includes both VMI
+    network interface IPs per endpoint (management cluster IP + guest cluster
+    internal IP). Since kube-proxy load-balances across all addresses, ~50% of
+    connections are routed to the unreachable guest-cluster IP, causing
+    intermittent failures from external clients. This task patches any dual-IP
+    EndpointSlices to keep only the management cluster IP per endpoint, and
+    creates EndpointSlices from scratch if none exist.
   params:
     - name: hostedClusterName
       type: string
@@ -103,7 +107,13 @@ spec:
         fi
         echo "   Found management service: ${MGMT_SVC_NAME}"
 
-        # Check if EndpointSlices already exist
+        # Check EndpointSlices for OCPBUGS-95615: control-plane-operator on OCP <4.22.z
+        # includes both VMI interface IPs per endpoint (management cluster IP + guest
+        # cluster ovn-k8s-mp0 IP). kube-proxy load-balances across all addresses, so
+        # ~50% of connections reach an unreachable IP. Fix: patch each slice to keep
+        # only addresses[0], which CAPK always orders first (the management cluster IP).
+        # This mirrors the upstream fix in HyperShift machine.go (OCPBUGS-95615).
+        # Once that fix ships in the OCP release the task becomes a no-op.
         echo ""
         echo "🔍 Checking EndpointSlices for ${MGMT_SVC_NAME}..."
         SLICE_COUNT=$(oc get endpointslice -n "${MGMT_NS}" \
@@ -111,11 +121,35 @@ spec:
           -o json | jq '.items | length')
 
         if [[ "${SLICE_COUNT}" -gt 0 ]]; then
-          echo "✅ EndpointSlices already exist (${SLICE_COUNT} found). Routing is working. Skipping workaround."
+          echo "   Found ${SLICE_COUNT} EndpointSlice(s). Checking for dual-IP endpoints (OCPBUGS-95615)..."
+          PATCHED_ANY=false
+          for SLICE_NAME in $(oc get endpointslice -n "${MGMT_NS}" \
+              -l "kubernetes.io/service-name=${MGMT_SVC_NAME}" \
+              -o jsonpath='{.items[*].metadata.name}'); do
+            SLICE_JSON=$(oc get endpointslice "${SLICE_NAME}" -n "${MGMT_NS}" -o json)
+            MAX_ADDRS=$(echo "${SLICE_JSON}" | jq '[.endpoints[].addresses | length] | max // 0')
+            if [[ "${MAX_ADDRS}" -gt 1 ]]; then
+              PATCHED_ANY=true
+              echo "   ⚠️  ${SLICE_NAME}: ${MAX_ADDRS} IPs/endpoint — patching to keep addresses[0] only..."
+              CLEAN=$(echo "${SLICE_JSON}" | jq '[.endpoints[] | .addresses = [.addresses[0]]]')
+              oc patch endpointslice "${SLICE_NAME}" -n "${MGMT_NS}" \
+                --type=merge -p "{\"endpoints\": ${CLEAN}}"
+              echo "   ✅ Patched ${SLICE_NAME}"
+            else
+              echo "   ✅ ${SLICE_NAME}: already single-IP per endpoint"
+            fi
+          done
+          if [[ "${PATCHED_ANY}" == "true" ]]; then
+            echo ""
+            echo "⚠️  Note: control-plane-operator owns these slices and will reconcile"
+            echo "   them back on the next Machine event. Run endpoint tests promptly."
+          else
+            echo "✅ All EndpointSlices already clean. No action needed."
+          fi
           exit 0
         fi
 
-        echo "🚨 Bug detected: No EndpointSlices found for ${MGMT_SVC_NAME}. Applying manual fix..."
+        echo "🚨 Bug detected: No EndpointSlices found for ${MGMT_SVC_NAME}. Applying manual fix (OCP 4.21 path)..."
 
         # Get the targetPort from the management service (https port)
         TARGET_PORT=$(oc get svc "${MGMT_SVC_NAME}" -n "${MGMT_NS}" \

--- a/.tekton/tasks/hcp-teardown-task.yaml
+++ b/.tekton/tasks/hcp-teardown-task.yaml
@@ -229,6 +229,20 @@ spec:
         oc delete secret "${SCC_SECRET_NAME}" --ignore-not-found=true && echo "   Deleted secret: ${SCC_SECRET_NAME}" || true
         oc delete secret "${CREDS_SECRET_NAME}" --ignore-not-found=true && echo "   Deleted secret: ${CREDS_SECRET_NAME}" || true
 
+        # Clean up Loki OBC on hub cluster
+        echo ""
+        echo "🧹 Cleaning up Loki OBC..."
+        OBC_NAME="loki-${CLUSTER_NAME}"
+        oc delete objectbucketclaim "${OBC_NAME}" -n openshift-storage --ignore-not-found=true \
+          && echo "   Deleted OBC: ${OBC_NAME}" || true
+
+        # Clean up Tempo OBC on hub cluster
+        echo ""
+        echo "🧹 Cleaning up Tempo OBC..."
+        OBC_NAME="tempo-${CLUSTER_NAME}"
+        oc delete objectbucketclaim "${OBC_NAME}" -n openshift-storage --ignore-not-found=true \
+          && echo "   Deleted OBC: ${OBC_NAME}" || true
+
         # Optionally cleanup namespace
         if [[ "${CLEANUP_NAMESPACE}" == "true" ]]; then
           echo ""

--- a/.tekton/tasks/hcp-verify-monitoring-task.yaml
+++ b/.tekton/tasks/hcp-verify-monitoring-task.yaml
@@ -9,10 +9,10 @@ metadata:
   name: hcp-verify-monitoring
 spec:
   description: >-
-    Creates NetworkPolicies to allow Prometheus scraping, then verifies
-    that SAP EIC ServiceMonitors are deployed and all Prometheus targets
-    are in Up state on the hosted cluster. Runs after EIC deployment
-    to confirm monitoring is working end-to-end.
+    Verifies that SAP EIC ServiceMonitors are deployed and all Prometheus
+    targets are in Up state on the hosted cluster. Runs after EIC deployment
+    to confirm monitoring is working end-to-end. NetworkPolicies for
+    Prometheus scraping are created earlier in enable-monitoring.
   params:
     - name: hostedClusterName
       type: string
@@ -92,40 +92,10 @@ spec:
         echo "✅ Successfully connected to hosted cluster"
         oc whoami
 
-        # Step 1: Create NetworkPolicies for Prometheus scraping
-        # Created here (after SAP ELM deployment) rather than in enable-monitoring
-        # to avoid breaking intra-namespace traffic before SAP deploys its own policies.
-        echo ""
-        echo "🔒 Step 1: Creating NetworkPolicies for Prometheus scraping..."
-
+        # Step 1: Check ServiceMonitors
         NAMESPACES=("edge-icell" "edge-icell-services" "edgelm")
-
-        for NS in "${NAMESPACES[@]}"; do
-          if oc get namespace "${NS}" &>/dev/null; then
-            echo "📦 Creating NetworkPolicy in ${NS}..."
-            cat <<EONP | oc apply -f -
-        apiVersion: networking.k8s.io/v1
-        kind: NetworkPolicy
-        metadata:
-          name: allow-from-openshift-user-workload-monitoring
-          namespace: ${NS}
-        spec:
-          podSelector: {}
-          ingress:
-          - from:
-            - namespaceSelector:
-                matchLabels:
-                  kubernetes.io/metadata.name: openshift-user-workload-monitoring
-        EONP
-            echo "✅ NetworkPolicy created in ${NS}"
-          else
-            echo "ℹ️  Namespace ${NS} does not exist, skipping NetworkPolicy"
-          fi
-        done
-
-        # Step 2: Check ServiceMonitors
         echo ""
-        echo "📊 Step 2: Checking ServiceMonitors..."
+        echo "📊 Step 1: Checking ServiceMonitors..."
         TOTAL_SM=0
 
         for NS in "${NAMESPACES[@]}"; do
@@ -168,7 +138,7 @@ spec:
 
         # Step 3: Query Prometheus targets
         echo ""
-        echo "📊 Step 3: Checking Prometheus targets..."
+        echo "📊 Step 2: Checking Prometheus targets..."
 
         # Get the Prometheus route or use port-forward
         PROM_HOST=""

--- a/edge-integration-cell/test_eic_endpoints.sh
+++ b/edge-integration-cell/test_eic_endpoints.sh
@@ -77,7 +77,7 @@ echo "--------------------------------------------------"
 
 
 echo "======== Sending New Request to https://${HOST}${ENDPOINT_PATH} ========"
-if curl --fail --insecure --show-error --request GET \
+if curl --fail --insecure --silent --show-error --request GET \
           -H "Authorization: Basic ${AUTH_KEY}" \
           "${CURL_OPTS[@]}" \
           --url "https://${HOST}${ENDPOINT_PATH}"; then


### PR DESCRIPTION
New task hcp-deploy-logging creates a per-cluster OBC on the hub for Loki S3 storage, installs Loki and Logging operators on the hosted cluster, and deploys the full logging stack (LokiStack, ServiceAccount, ClusterLogForwarder, UIPlugin) following the KBA guide. The pipeline runs it in Phase 3 parallel with PostgreSQL/Redis deployment. Teardown cleans up the OBC from the hub.